### PR TITLE
fix: metadata type to 'UNKNOWN' when type is NULL

### DIFF
--- a/cpp/bridge.cpp
+++ b/cpp/bridge.cpp
@@ -382,7 +382,7 @@ namespace opsqlite {
                             auto metadata = DynamicHostObject();
                             metadata.fields.push_back(std::make_pair("name", column_name));
                             metadata.fields.push_back(std::make_pair("index", i));
-                            metadata.fields.push_back(std::make_pair("type", type));
+                            metadata.fields.push_back(std::make_pair("type", type == NULL ? "UNKNOWN" : type));
                             
                             metadatas->push_back(metadata);
                             i++;

--- a/example/src/tests/queries.spec.ts
+++ b/example/src/tests/queries.spec.ts
@@ -99,6 +99,52 @@ export function queriesTests() {
       ]);
     });
 
+    it('Query with sqlite functions', async () => {
+      const id = chance.integer();
+      const name = chance.name();
+      const age = chance.integer();
+      const networth = chance.floating();
+
+      // COUNT(*)
+      db.execute(
+        'INSERT INTO User (id, name, age, networth) VALUES(?, ?, ?, ?)',
+        [id, name, age, networth],
+      );
+
+      const countRes = db.execute('SELECT COUNT(*) as count FROM User');
+
+      expect(countRes.metadata?.[0].type).to.equal('UNKNOWN');
+      expect(countRes.rows?._array.length).to.equal(1);
+      expect(countRes.rows?.item(0).count).to.equal(1);
+
+      // SUM(age)
+      const id2 = chance.integer();
+      const name2 = chance.name();
+      const age2 = chance.integer();
+      const networth2 = chance.floating();
+
+      db.execute(
+        'INSERT INTO User (id, name, age, networth) VALUES(?, ?, ?, ?)',
+        [id2, name2, age2, networth2],
+      );
+
+      const sumRes = db.execute('SELECT SUM(age) as sum FROM User;');
+    
+      expect(sumRes.metadata?.[0].type).to.equal('UNKNOWN');
+      expect(sumRes.rows?.item(0).sum).to.equal(age + age2);
+
+      // MAX(networth), MIN(networth)
+      const maxRes = db.execute('SELECT MAX(networth) as `max` FROM User;');
+      const minRes = db.execute('SELECT MIN(networth) as `min` FROM User;');
+      expect(maxRes.metadata?.[0].type).to.equal('UNKNOWN');
+      expect(minRes.metadata?.[0].type).to.equal('UNKNOWN');
+      const maxNetworth = Math.max(networth, networth2);
+      const minNetworth = Math.min(networth, networth2);
+
+      expect(maxRes.rows?.item(0).max).to.equal(maxNetworth);
+      expect(minRes.rows?.item(0).min).to.equal(minNetworth);
+    });
+
     it('Executes all the statements in a single string', async () => {
       db.execute(
         `CREATE TABLE T1 ( id INT PRIMARY KEY) STRICT;


### PR DESCRIPTION

## Background 
When I use COUNT/MAX as column then the app crash on Android. Finally find out sqlite3_column_decltype return NULL    when using sqlite functions.

```js
const db = open({
  name: 'test.db',
})

console.log('create table test', db.execute('CREATE TABLE IF NOT EXISTS test (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, age INTEGER NOT NULL);'))

export default function App() {
  useEffect(() => {
    const query = db.execute('select COUNT(*) from test;')
    console.log('query', query)
  }, [])
  return (
    <SafeAreaView className="flex-1 bg-neutral-900">
      <View>
        <Text>Hello World</Text>
      </View>
    </SafeAreaView>
  );
}
```

## Fix

When type == NULL, return "UNKNOWN" instead.