### PR TITLE
Add methods to remove hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,18 +76,15 @@ db = {
   executeBatchAsync: (commands: SQLBatchTuple[]) => Promise<BatchQueryResult>,
   loadFile: (location: string) => Promise<FileLoadResult>,
   updateHook: (
-    callback: (params: {
+    callback: ((params: {
       table: string;
       operation: UpdateHookOperation;
       row?: any;
       rowId: number;
-    }) => void
+    }) => void) | null
   ) => void,
-  commitHook: (callback: () => void) => void,
-  rollbackHook: (callback: () => void) => void,
-  removeUpdateHook: () => void,
-  removeCommitHook: () => void,
-  removeRollbackHook: () => void
+  commitHook: (callback: (() => void) | null) => void,
+  rollbackHook: (callback: (() => void) | null) => void
 }
 ```
 
@@ -343,14 +340,14 @@ try {
 }
 ```
 
-You can remove hooks event at any moment:
+You can pass `null`` to remove hooks at any moment:
 
 ```ts
-db.removeUpdateHook();
+db.updateHook(null);
 
-db.removeCommitHook();
+db.commitHook(null);
 
-db.removeRollbackHook();
+db.rollbackHook(null);
 ```
 
 ## Use built-in SQLite

--- a/README.md
+++ b/README.md
@@ -69,15 +69,25 @@ db = {
   delete: () => void,
   attach: (dbNameToAttach: string, alias: string, location?: string) => void,
   detach: (alias: string) => void,
-  transaction: (fn: (tx: Transaction) => void) => Promise<void>,
+  transaction: (fn: (tx: Transaction) => Promise<void>) => Promise<void>,
   execute: (query: string, params?: any[]) => QueryResult,
-  executeAsync: (
-    query: string,
-    params?: any[]
-  ) => Promise<QueryResult>,
-  executeBatch: (commands: SQLBatchParams[]) => BatchQueryResult,
-  executeBatchAsync: (commands: SQLBatchParams[]) => Promise<BatchQueryResult>,
-  loadFile: (location: string) => Promise<FileLoadResult>
+  executeAsync: (query: string, params?: any[]) => Promise<QueryResult>,
+  executeBatch: (commands: SQLBatchTuple[]) => BatchQueryResult,
+  executeBatchAsync: (commands: SQLBatchTuple[]) => Promise<BatchQueryResult>,
+  loadFile: (location: string) => Promise<FileLoadResult>,
+  updateHook: (
+    callback: (params: {
+      table: string;
+      operation: UpdateHookOperation;
+      row?: any;
+      rowId: number;
+    }) => void
+  ) => void,
+  commitHook: (callback: () => void) => void,
+  rollbackHook: (callback: () => void) => void,
+  removeUpdateHook: () => void,
+  removeCommitHook: () => void,
+  removeRollbackHook: () => void
 }
 ```
 
@@ -331,6 +341,16 @@ try {
 } catch (e) {
   // intentionally left blank
 }
+```
+
+You can remove hooks event at any moment:
+
+```ts
+db.removeUpdateHook();
+
+db.removeCommitHook();
+
+db.removeRollbackHook();
 ```
 
 ## Use built-in SQLite

--- a/cpp/bindings.cpp
+++ b/cpp/bindings.cpp
@@ -480,6 +480,21 @@ void install(jsi::Runtime &rt, std::shared_ptr<react::CallInvoker> jsCallInvoker
         
         return {};
     });
+
+    auto removeUpdateHook = HOSTFN("removeUpdateHook", 1)
+    {
+        if (sizeof(args) < 2)
+        {
+            throw jsi::JSError(rt, "[op-sqlite][loadFileAsync] Incorrect parameters: dbName needed");
+            return {};
+        }
+        
+        auto dbName = args[0].asString(rt).utf8(rt);
+
+        unregisterUpdateHook(dbName);
+        
+        return {};
+    });
     
     auto commitHook = HOSTFN("commitHook", 2)
     {
@@ -504,7 +519,22 @@ void install(jsi::Runtime &rt, std::shared_ptr<react::CallInvoker> jsCallInvoker
         
         return {};
     });
-    
+
+    auto removeCommitHook = HOSTFN("removeCommitHook", 2)
+    {
+        if (sizeof(args) < 2)
+        {
+            throw jsi::JSError(rt, "[op-sqlite][loadFileAsync] Incorrect parameters: dbName needed");
+            return {};
+        }
+        
+        auto dbName = args[0].asString(rt).utf8(rt);
+        
+        unregisterCommitHook(dbName);
+        
+        return {};
+    });
+
     auto rollbackHook = HOSTFN("rollbackHook", 2)
     {
         if (sizeof(args) < 2)
@@ -529,6 +559,21 @@ void install(jsi::Runtime &rt, std::shared_ptr<react::CallInvoker> jsCallInvoker
         
         return {};
     });
+
+    auto removeRollbackHook = HOSTFN("removeRollbackHook", 2)
+    {
+        if (sizeof(args) < 2)
+        {
+            throw jsi::JSError(rt, "[op-sqlite][loadFileAsync] Incorrect parameters: dbName needed");
+            return {};
+        }
+        
+        auto dbName = args[0].asString(rt).utf8(rt);
+        
+        unregisterRollbackHook(dbName);
+        
+        return {};
+    });
     
     jsi::Object module = jsi::Object(rt);
     
@@ -543,8 +588,11 @@ void install(jsi::Runtime &rt, std::shared_ptr<react::CallInvoker> jsCallInvoker
     module.setProperty(rt, "executeBatchAsync", std::move(executeBatchAsync));
     module.setProperty(rt, "loadFile", std::move(loadFile));
     module.setProperty(rt, "updateHook", std::move(updateHook));
+    module.setProperty(rt, "removeUpdateHook", std::move(removeUpdateHook));
     module.setProperty(rt, "commitHook", std::move(commitHook));
+    module.setProperty(rt, "removeCommitHook", std::move(removeCommitHook));
     module.setProperty(rt, "rollbackHook", std::move(rollbackHook));
+    module.setProperty(rt, "removeRollbackHook", std::move(removeRollbackHook));
     
     rt.global().setProperty(rt, "__OPSQLiteProxy", std::move(module));
 }

--- a/cpp/bridge.cpp
+++ b/cpp/bridge.cpp
@@ -560,6 +560,28 @@ namespace opsqlite {
         };
     }
 
+    BridgeResult unregisterUpdateHook(std::string const dbName) {
+        if (dbMap.count(dbName) == 0)
+        {
+            return {
+                SQLiteError,
+                "[op-sqlite] Database not opened: " + dbName
+            };
+        }
+        
+        sqlite3 *db = dbMap[dbName];
+        updateCallbackMap.erase(dbName);
+
+        sqlite3_update_hook(
+            db,
+            NULL,
+            NULL);
+
+        return {
+            SQLiteOk
+        };
+    }
+
     int commit_callback(void *dbName) {
         std::string &strDbName = *(static_cast<std::string*>(dbName));
         auto callback = commitCallbackMap[strDbName];
@@ -599,6 +621,27 @@ namespace opsqlite {
         };
     }
 
+    BridgeResult unregisterCommitHook(std::string const dbName) {
+        if (dbMap.count(dbName) == 0)
+        {
+            return {
+                SQLiteError,
+                "[op-sqlite] Database not opened: " + dbName
+            };
+        }
+        
+        sqlite3 *db = dbMap[dbName];
+        commitCallbackMap.erase(dbName);
+        sqlite3_commit_hook(
+            db,
+            NULL,
+            NULL);
+
+        return {
+            SQLiteOk
+        };
+    }
+
     void rollback_callback(void *dbName) {
         std::string &strDbName = *(static_cast<std::string*>(dbName));
         auto callback = rollbackCallbackMap[strDbName];
@@ -631,6 +674,28 @@ namespace opsqlite {
           &rollback_callback,
           (void *)key);
         
+        return {
+            SQLiteOk
+        };
+    }
+
+    BridgeResult unregisterRollbackHook(std::string const dbName) {
+        if (dbMap.count(dbName) == 0)
+        {
+            return {
+                SQLiteError,
+                "[op-sqlite] Database not opened: " + dbName
+            };
+        }
+        
+        sqlite3 *db = dbMap[dbName];
+        rollbackCallbackMap.erase(dbName);
+
+        sqlite3_rollback_hook(
+            db,
+            NULL,
+            NULL);
+
         return {
             SQLiteOk
         };

--- a/cpp/bridge.cpp
+++ b/cpp/bridge.cpp
@@ -367,27 +367,30 @@ namespace opsqlite {
                             }
                             i++;
                         }
-                        results->push_back(row);
+                        if (results != nullptr) {
+                            results->push_back(row);
+                        }
                         break;
                     }
                         
                     case SQLITE_DONE:
-                        i = 0;
-                        count = sqlite3_column_count(statement);
-                        
-                        while (i < count)
-                        {
-                            column_name = sqlite3_column_name(statement, i);
-                            const char *type = sqlite3_column_decltype(statement, i);
-                            auto metadata = DynamicHostObject();
-                            metadata.fields.push_back(std::make_pair("name", column_name));
-                            metadata.fields.push_back(std::make_pair("index", i));
-                            metadata.fields.push_back(std::make_pair("type", type == NULL ? "UNKNOWN" : type));
+                        if (metadatas != nullptr) {
+                            i = 0;
+                            count = sqlite3_column_count(statement);
                             
-                            metadatas->push_back(metadata);
-                            i++;
+                            while (i < count)
+                            {
+                                column_name = sqlite3_column_name(statement, i);
+                                const char *type = sqlite3_column_decltype(statement, i);
+                                auto metadata = DynamicHostObject();
+                                metadata.fields.push_back(std::make_pair("name", column_name));
+                                metadata.fields.push_back(std::make_pair("index", i));
+                                metadata.fields.push_back(std::make_pair("type", type == NULL ? "UNKNOWN" : type));
+                                
+                                metadatas->push_back(metadata);
+                                i++;
+                            }
                         }
-                        
                         isConsuming = false;
                         break;
                         

--- a/cpp/bridge.h
+++ b/cpp/bridge.h
@@ -33,11 +33,13 @@ void sqliteCloseAll();
 
 BridgeResult registerUpdateHook(std::string const dbName, 
                                 std::function<void (std::string dbName, std::string tableName, std::string operation, int rowId)> const callback);
+BridgeResult unregisterUpdateHook(std::string const dbName);
 BridgeResult registerCommitHook(std::string const dbName,
                                 std::function<void (std::string dbName)> const callback);
+BridgeResult unregisterCommitHook(std::string const dbName);
 BridgeResult registerRollbackHook(std::string const dbName,
                                   std::function<void (std::string dbName)> const callback);
-
+BridgeResult unregisterRollbackHook(std::string const dbName);
 }
 
 #endif /* bridge_h */

--- a/example/src/tests/hooks.ts
+++ b/example/src/tests/hooks.ts
@@ -65,6 +65,33 @@ export function registerHooksTests() {
       expect(operation).to.equal('INSERT');
     });
 
+    it('remove update hook', async () => {
+      const hookRes: string[] = []
+      db.updateHook(({ rowId, table, operation, row = {} }) => {
+        hookRes.push(operation);
+      });
+
+      const id = chance.integer();
+      const name = chance.name();
+      const age = chance.integer();
+      const networth = chance.floating();
+      db.execute(
+        'INSERT INTO "User" (id, name, age, networth) VALUES(?, ?, ?, ?)',
+        [id, name, age, networth],
+      );
+
+      db.removeUpdateHook()
+
+      db.execute(
+        'INSERT INTO "User" (id, name, age, networth) VALUES(?, ?, ?, ?)',
+        [id + 1, name, age, networth],
+      );
+
+      await sleep(100)
+
+      expect(hookRes.length).to.equal(1)
+    });
+
     it('commit hook', async () => {
       let promiseResolve: any;
       let promise = new Promise(resolve => {
@@ -87,6 +114,37 @@ export function registerHooksTests() {
       });
 
       await promise;
+    });
+
+    it('remove commit hook', async () => {
+      const hookRes: string[] = []
+      db.commitHook(() => {
+        hookRes.push('commit');
+      });
+
+      const id = chance.integer();
+      const name = chance.name();
+      const age = chance.integer();
+      const networth = chance.floating();
+      await db.transaction(async tx => {
+        tx.execute(
+          'INSERT INTO "User" (id, name, age, networth) VALUES(?, ?, ?, ?)',
+          [id, name, age, networth],
+        );
+      });
+
+      db.removeCommitHook()
+
+      await db.transaction(async tx => {
+        tx.execute(
+          'INSERT INTO "User" (id, name, age, networth) VALUES(?, ?, ?, ?)',
+          [id+1, name, age, networth],
+        );
+      });
+
+      await sleep(100)
+
+      expect(hookRes.length).to.equal(1)
     });
 
     it('rollback hook', async () => {
@@ -114,6 +172,35 @@ export function registerHooksTests() {
 
       console.warn('2');
       await promise;
+    });
+
+    it('remove rollback hook', async () => {
+      const hookRes: string[] = []
+      db.rollbackHook(() => {
+        hookRes.push('rollback');
+      });
+
+      try {
+        await db.transaction(async tx => {
+          throw new Error('Blah');
+        });
+      } catch (e) {
+        // intentionally left blank
+      }
+
+      db.removeRollbackHook()
+
+      try {
+        await db.transaction(async tx => {
+          throw new Error('Blah');
+        });
+      } catch (e) {
+        // intentionally left blank
+      }
+
+      await sleep(100)
+
+      expect(hookRes.length).to.equal(1)
     });
   });
 }

--- a/example/src/tests/hooks.ts
+++ b/example/src/tests/hooks.ts
@@ -87,7 +87,7 @@ export function registerHooksTests() {
         [id + 1, name, age, networth],
       );
 
-      await sleep(100)
+      await sleep(0)
 
       expect(hookRes.length).to.equal(1)
     });
@@ -142,7 +142,7 @@ export function registerHooksTests() {
         );
       });
 
-      await sleep(100)
+      await sleep(0)
 
       expect(hookRes.length).to.equal(1)
     });
@@ -198,7 +198,7 @@ export function registerHooksTests() {
         // intentionally left blank
       }
 
-      await sleep(100)
+      await sleep(0)
 
       expect(hookRes.length).to.equal(1)
     });

--- a/example/src/tests/hooks.ts
+++ b/example/src/tests/hooks.ts
@@ -80,7 +80,7 @@ export function registerHooksTests() {
         [id, name, age, networth],
       );
 
-      db.removeUpdateHook()
+      db.updateHook(null)
 
       db.execute(
         'INSERT INTO "User" (id, name, age, networth) VALUES(?, ?, ?, ?)',
@@ -133,7 +133,7 @@ export function registerHooksTests() {
         );
       });
 
-      db.removeCommitHook()
+      db.commitHook(null)
 
       await db.transaction(async tx => {
         tx.execute(
@@ -188,7 +188,7 @@ export function registerHooksTests() {
         // intentionally left blank
       }
 
-      db.removeRollbackHook()
+      db.rollbackHook(null)
 
       try {
         await db.transaction(async tx => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,18 +161,15 @@ interface ISQLite {
   loadFile: (dbName: string, location: string) => Promise<FileLoadResult>;
   updateHook: (
     dbName: string,
-    callback: (params: {
+    callback?: ((params: {
       table: string;
       operation: UpdateHookOperation;
       row?: any;
       rowId: number;
-    }) => void
+    }) => void) | null
   ) => void;
-  commitHook: (dbName: string, callback: () => void) => void;
-  rollbackHook: (dbName: string, callback: () => void) => void;
-  removeUpdateHook: (dbName: string) => void;
-  removeCommitHook: (dbName: string) => void;
-  removeRollbackHook: (dbName: string) => void;
+  commitHook: (dbName: string, callback?: (() => void) | null) => void;
+  rollbackHook: (dbName: string, callback?: (() => void) | null) => void;
 }
 
 const locks: Record<
@@ -418,26 +415,8 @@ export const open = (options: {
     executeBatchAsync: (commands: SQLBatchTuple[]) =>
       OPSQLite.executeBatchAsync(options.name, commands),
     loadFile: (location: string) => OPSQLite.loadFile(options.name, location),
-    updateHook: (callback) => {
-      if (callback != null) {
-        OPSQLite.updateHook(options.name, callback)
-      } else {
-        OPSQLite.removeUpdateHook(options.name)
-      }
-    },
-    commitHook: (callback) => {
-      if (callback != null) {
-        OPSQLite.commitHook(options.name, callback)
-      } else {
-        OPSQLite.removeCommitHook(options.name)
-      }
-    },
-    rollbackHook: (callback) => {
-      if (callback != null) {
-        OPSQLite.rollbackHook(options.name, callback)
-      } else {
-        OPSQLite.removeRollbackHook(options.name)
-      }
-    }
+    updateHook: (callback) => OPSQLite.updateHook(options.name, callback),
+    commitHook: (callback) => OPSQLite.commitHook(options.name, callback),
+    rollbackHook: (callback) => OPSQLite.rollbackHook(options.name, callback),
   };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -380,18 +380,15 @@ export type OPSQLiteConnection = {
   executeBatchAsync: (commands: SQLBatchTuple[]) => Promise<BatchQueryResult>;
   loadFile: (location: string) => Promise<FileLoadResult>;
   updateHook: (
-    callback: (params: {
+    callback: ((params: {
       table: string;
       operation: UpdateHookOperation;
       row?: any;
       rowId: number;
-    }) => void
+    }) => void) | null
   ) => void;
-  commitHook: (callback: () => void) => void;
-  rollbackHook: (callback: () => void) => void;
-  removeUpdateHook: () => void;
-  removeCommitHook: () => void;
-  removeRollbackHook: () => void;
+  commitHook: (callback: (() => void) | null) => void;
+  rollbackHook: (callback: (() => void) | null) => void;
 };
 
 export const open = (options: {
@@ -421,11 +418,26 @@ export const open = (options: {
     executeBatchAsync: (commands: SQLBatchTuple[]) =>
       OPSQLite.executeBatchAsync(options.name, commands),
     loadFile: (location: string) => OPSQLite.loadFile(options.name, location),
-    updateHook: (callback) => OPSQLite.updateHook(options.name, callback),
-    commitHook: (callback) => OPSQLite.commitHook(options.name, callback),
-    rollbackHook: (callback) => OPSQLite.rollbackHook(options.name, callback),
-    removeUpdateHook: () => OPSQLite.removeUpdateHook(options.name),
-    removeCommitHook: () => OPSQLite.removeCommitHook(options.name),
-    removeRollbackHook: () => OPSQLite.removeRollbackHook(options.name),
+    updateHook: (callback) => {
+      if (callback != null) {
+        OPSQLite.updateHook(options.name, callback)
+      } else {
+        OPSQLite.removeUpdateHook(options.name)
+      }
+    },
+    commitHook: (callback) => {
+      if (callback != null) {
+        OPSQLite.commitHook(options.name, callback)
+      } else {
+        OPSQLite.removeCommitHook(options.name)
+      }
+    },
+    rollbackHook: (callback) => {
+      if (callback != null) {
+        OPSQLite.rollbackHook(options.name, callback)
+      } else {
+        OPSQLite.removeRollbackHook(options.name)
+      }
+    }
   };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,6 +170,9 @@ interface ISQLite {
   ) => void;
   commitHook: (dbName: string, callback: () => void) => void;
   rollbackHook: (dbName: string, callback: () => void) => void;
+  removeUpdateHook: (dbName: string) => void;
+  removeCommitHook: (dbName: string) => void;
+  removeRollbackHook: (dbName: string) => void;
 }
 
 const locks: Record<
@@ -386,6 +389,9 @@ export type OPSQLiteConnection = {
   ) => void;
   commitHook: (callback: () => void) => void;
   rollbackHook: (callback: () => void) => void;
+  removeUpdateHook: () => void;
+  removeCommitHook: () => void;
+  removeRollbackHook: () => void;
 };
 
 export const open = (options: {
@@ -418,5 +424,8 @@ export const open = (options: {
     updateHook: (callback) => OPSQLite.updateHook(options.name, callback),
     commitHook: (callback) => OPSQLite.commitHook(options.name, callback),
     rollbackHook: (callback) => OPSQLite.rollbackHook(options.name, callback),
+    removeUpdateHook: () => OPSQLite.removeUpdateHook(options.name),
+    removeCommitHook: () => OPSQLite.removeCommitHook(options.name),
+    removeRollbackHook: () => OPSQLite.removeRollbackHook(options.name),
   };
 };


### PR DESCRIPTION
## Changes

- null guard for sqliteExecute params: `results` and `metadatas`, I accidentally call `SELECT * FROM TABLE` with `executeBatch` it crash, cause null pointer error.

- add methods to remove hooks, so we can implement features like add hook when enter or remove hook when exit. 