### PR TITLE
bumps deployment targets versions

### DIFF
--- a/op-sqlite.podspec
+++ b/op-sqlite.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => "12.0", :osx => "10.13" }
+  s.platforms    = { :ios => "13.0", :osx => "10.15" }
   s.source       = { :git => "https://github.com/op-engineering/op-sqlite.git", :tag => "#{s.version}" }
 
   s.pod_target_xcconfig = {


### PR DESCRIPTION
Trying to upgrade to the latest version, I've stumbled on `'create_directories' is unavailable: introduced in iOS 13.0` and `'path' is unavailable: introduced in iOS 13.0` errors in `cpp/utils.cpp`

Bumping deployment targets fixed that. Alternatively, reverting the changes would avoid the bump, but 12.0 is not supported by many libs (Expo, as an example), so seams also like a viable approach 