### PR TITLE
add load extension binding

### DIFF
--- a/cpp/bindings.cpp
+++ b/cpp/bindings.cpp
@@ -540,6 +540,21 @@ void install(jsi::Runtime &rt,
     return jsi::Object::createFromHostObject(rt, preparedStatementHostObject);
   });
 
+  auto load_extension = HOSTFN("loadExtension", 2) {
+    auto db_name = args[0].asString(rt).utf8(rt);
+    auto path = args[1].asString(rt).utf8(rt);
+    std::string entryPoint = "";
+    if (count > 2 && args[2].isString()) {
+      entryPoint = args[2].asString(rt).utf8(rt);
+    }
+
+    auto result = sqlite_load_extension(db_name, path, entryPoint);
+    if (result.type == SQLiteError) {
+      throw std::runtime_error(result.message);
+    }
+    return {};
+  });
+
   jsi::Object module = jsi::Object(rt);
 
   module.setProperty(rt, "open", std::move(open));
@@ -556,6 +571,7 @@ void install(jsi::Runtime &rt,
   module.setProperty(rt, "commitHook", std::move(commitHook));
   module.setProperty(rt, "rollbackHook", std::move(rollbackHook));
   module.setProperty(rt, "prepareStatement", std::move(prepareStatement));
+  module.setProperty(rt, "loadExtension", std::move(load_extension));
 
   rt.global().setProperty(rt, "__OPSQLiteProxy", std::move(module));
 }

--- a/cpp/bridge.cpp
+++ b/cpp/bridge.cpp
@@ -731,4 +731,32 @@ BridgeResult sqlite_deregister_rollback_hook(std::string const &dbName) {
 
   return {SQLiteOk};
 }
+
+BridgeResult sqlite_load_extension(std::string &db_name, std::string &path,
+                                   std::string &entry_point) {
+  if (dbMap.count(db_name) == 0) {
+    return {SQLiteError, "[op-sqlite] Database not open"};
+  }
+
+  sqlite3 *db = dbMap[db_name];
+  int loading_extensions_enabled = sqlite3_enable_load_extension(db, 1);
+  if (loading_extensions_enabled != SQLITE_OK) {
+    return {SQLiteError, "[op-sqlite] could not enable extension loading"};
+  }
+  const char *path_cstr = path.c_str();
+  const char *entry_point_cstr;
+  if (!entry_point.empty()) {
+    entry_point_cstr = entry_point.c_str();
+  }
+
+  char *error_message;
+
+  int extension_loaded =
+      sqlite3_load_extension(db, path_cstr, entry_point_cstr, &error_message);
+  if (extension_loaded != SQLITE_OK) {
+    return {SQLiteError, std::string(error_message)};
+  }
+  return {SQLiteOk};
+}
+
 } // namespace opsqlite

--- a/cpp/bridge.h
+++ b/cpp/bridge.h
@@ -62,6 +62,10 @@ BridgeResult sqlite_execute_prepared_statement(
     std::string const &dbName, sqlite3_stmt *statement,
     std::vector<DumbHostObject> *results,
     std::shared_ptr<std::vector<SmartHostObject>> metadatas);
+
+BridgeResult sqlite_load_extension(std::string &db_name, std::string &path,
+                                   std::string &entry_point);
+
 } // namespace opsqlite
 
 #endif /* bridge_h */

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -23,9 +23,10 @@ import clsx from 'clsx';
 import {preparedStatementsTests} from './tests/preparedStatements.spec';
 import {constantsTests} from './tests/constants.spec';
 import performance from 'react-native-performance';
-import UpdateHookPage from './UpdateHook';
+// import UpdateHookPage from './UpdateHook';
 import {MMKV} from 'react-native-mmkv';
 export const mmkv = new MMKV();
+
 const StyledScrollView = styled(ScrollView, {
   props: {
     contentContainerStyle: true,
@@ -251,7 +252,7 @@ export default function App() {
           </Text>
         )}
 
-        <UpdateHookPage />
+        {/* <UpdateHookPage /> */}
 
         <Text
           className={clsx('font-bold flex-1 text-white p-2 mt-4', {

--- a/example/src/tests/dbsetup.spec.ts
+++ b/example/src/tests/dbsetup.spec.ts
@@ -36,6 +36,18 @@ export function dbSetupTests() {
       });
     }
 
+    it('Should load extension on runtime', async () => {
+      let db = open({
+        name: 'extensionDb',
+      });
+      try {
+        db.loadExtension('path');
+      } catch (e) {
+        // TODO load a sample extension
+        expect(e).to.exist;
+      }
+    });
+
     // it('Should fail creating in-memory with non-bool arg', async () => {
     //   try {
     //     open({

--- a/src/index.ts
+++ b/src/index.ts
@@ -193,6 +193,7 @@ interface ISQLite {
   commitHook: (dbName: string, callback?: (() => void) | null) => void;
   rollbackHook: (dbName: string, callback?: (() => void) | null) => void;
   prepareStatement: (dbName: string, query: string) => PreparedStatementObj;
+  loadExtension: (dbName: string, path: string, entryPoint?: string) => void;
 }
 
 const locks: Record<
@@ -412,6 +413,7 @@ export type OPSQLiteConnection = {
   commitHook: (callback: (() => void) | null) => void;
   rollbackHook: (callback: (() => void) | null) => void;
   prepareStatement: (query: string) => PreparedStatementObj;
+  loadExtension: (path: string, entryPoint?: string) => void;
 };
 
 export const open = (options: {
@@ -444,5 +446,7 @@ export const open = (options: {
     commitHook: (callback) => OPSQLite.commitHook(options.name, callback),
     rollbackHook: (callback) => OPSQLite.rollbackHook(options.name, callback),
     prepareStatement: (query) => OPSQLite.prepareStatement(options.name, query),
+    loadExtension: (path, entryPoint) =>
+      OPSQLite.loadExtension(options.name, path, entryPoint),
   };
 };


### PR DESCRIPTION
takes care of #30 

This only enables the API to load an extension. You still need to compile it and place it in a reachable spot (aka a sandbox friendly location in disk) so that sqlite can load into memory. This also means you will have to create a `.so` per OS and possibly contain multiple architectures (ios sim, ios arm sim, ios and for android all the arm versions) so that it gets loaded correctly.

I have not tested such compilation myself yet and would be great if someone can give a hand and test this on their own and confirm it is workin.