### PR TITLE
OP_SQLITE_PERF=1 crashes with Async Methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ db.execute('PRAGMA journal_mode = MEMORY;'); // or OFF
 
 If you use [prepared statements](#prepared-statements) are useful to reduce the time of critical queries.
 
-# Perf flag
+# Perf flags
 
 You can turn on the performance flag to tweak all possible performance enhancing compilation flags, this greatly affects performance of sqlite itself:
 
@@ -147,6 +147,17 @@ If correctly set you should see the following output in your console
 OP-SQLITE performance mode enabled! 🚀
 ```
 
+## Thread safety
+Please, note that OP_SQLITE_PERF=1 will disable Thread Safe support of SQLite, and you will be unable to use async methods from this library, otherwise it will crash.
+If you still want to have the benefits of the enhanced compilation flags and keep thread safety, you can use OP_SQLITE_PERF=2. This will have some performance loss (because of SQLite mutexes) but you can continue to use async background methods.
+
+If correctly set you should see the following output in your console
+
+```sh
+OP-SQLITE (thread safe) performance mode enabled! 🚀
+```
+
+Here you can read more about [SQLite Thread Safe](https://www.sqlite.org/threadsafe.html)
 # SQLite Gotchas
 
 ## Strictness

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ If you use [prepared statements](#prepared-statements) are useful to reduce the 
 
 # Perf flags
 
-You can turn on the performance flag to tweak all possible performance enhancing compilation flags, this greatly affects performance of sqlite itself:
+You can turn on the performance flag to tweak all possible performance enhancing compilation flags, this greatly affects performance of sqlite itself. Be aware this disables thread safety, you should only uses transactions (which operate based on a mutex in JS side) to avoid any issues.
 
 ```sh
 # For iOS install pods with the following env variable, you can also just an export like on Android
@@ -147,10 +147,7 @@ If correctly set you should see the following output in your console
 OP-SQLITE performance mode enabled! 🚀
 ```
 
-## Thread safety
-Please, note that OP_SQLITE_PERF=1 will disable Thread Safe support of SQLite, and you will be unable to use async methods from this library, otherwise it will crash.
-If you still want to have the benefits of the enhanced compilation flags and keep thread safety, you can use OP_SQLITE_PERF=2. This will have some performance loss (because of SQLite mutexes) but you can continue to use async background methods.
-
+If you want to keep SQLite thread safety based on mutexes, you can use OP_SQLITE_PERF=2. This flag will enable the general compilation flags, except DSQLITE_THREADSAFE=0.
 If correctly set you should see the following output in your console
 
 ```sh

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -81,7 +81,7 @@ android {
               cFlags "-DSQLITE_DQS=0", "-DSQLITE_THREADSAFE=0", "-DSQLITE_DEFAULT_MEMSTATUS=0", "-DSQLITE_DEFAULT_WAL_SYNCHRONOUS=1", "-DSQLITE_LIKE_DOESNT_MATCH_BLOBS=1", "-DSQLITE_MAX_EXPR_DEPTH=0", "-DSQLITE_OMIT_DEPRECATED=1", "-DSQLITE_OMIT_PROGRESS_CALLBACK=1", "-DSQLITE_OMIT_SHARED_CACHE=1", "-DSQLITE_USE_ALLOCA=1"
             }
             if(System.getenv("OP_SQLITE_PERF") == '2') {
-              println "OP-SQLITE performance mode enabled! 🚀"
+              println "OP-SQLITE (thread safe) performance mode enabled! 🚀"
               cFlags "-DSQLITE_DQS=0", "-DSQLITE_THREADSAFE=1", "-DSQLITE_DEFAULT_MEMSTATUS=0", "-DSQLITE_DEFAULT_WAL_SYNCHRONOUS=1", "-DSQLITE_LIKE_DOESNT_MATCH_BLOBS=1", "-DSQLITE_MAX_EXPR_DEPTH=0", "-DSQLITE_OMIT_DEPRECATED=1", "-DSQLITE_OMIT_PROGRESS_CALLBACK=1", "-DSQLITE_OMIT_SHARED_CACHE=1", "-DSQLITE_USE_ALLOCA=1"
             }
             cppFlags "-O2", "-fexceptions", "-frtti", "-std=c++1y", "-DONANDROID"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -80,6 +80,10 @@ android {
               println "OP-SQLITE performance mode enabled! 🚀"
               cFlags "-DSQLITE_DQS=0", "-DSQLITE_THREADSAFE=0", "-DSQLITE_DEFAULT_MEMSTATUS=0", "-DSQLITE_DEFAULT_WAL_SYNCHRONOUS=1", "-DSQLITE_LIKE_DOESNT_MATCH_BLOBS=1", "-DSQLITE_MAX_EXPR_DEPTH=0", "-DSQLITE_OMIT_DEPRECATED=1", "-DSQLITE_OMIT_PROGRESS_CALLBACK=1", "-DSQLITE_OMIT_SHARED_CACHE=1", "-DSQLITE_USE_ALLOCA=1"
             }
+            if(System.getenv("OP_SQLITE_PERF") == '2') {
+              println "OP-SQLITE performance mode enabled! 🚀"
+              cFlags "-DSQLITE_DQS=0", "-DSQLITE_THREADSAFE=1", "-DSQLITE_DEFAULT_MEMSTATUS=0", "-DSQLITE_DEFAULT_WAL_SYNCHRONOUS=1", "-DSQLITE_LIKE_DOESNT_MATCH_BLOBS=1", "-DSQLITE_MAX_EXPR_DEPTH=0", "-DSQLITE_OMIT_DEPRECATED=1", "-DSQLITE_OMIT_PROGRESS_CALLBACK=1", "-DSQLITE_OMIT_SHARED_CACHE=1", "-DSQLITE_USE_ALLOCA=1"
+            }
             cppFlags "-O2", "-fexceptions", "-frtti", "-std=c++1y", "-DONANDROID"
             abiFilters 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'
             arguments '-DANDROID_STL=c++_shared',

--- a/cpp/bindings.cpp
+++ b/cpp/bindings.cpp
@@ -418,8 +418,9 @@ void install(jsi::Runtime &rt,
                                   jsi::Value(batchResult.affectedRows));
                   resolve->asObject(rt).asFunction(rt).call(rt, std::move(res));
                 } else {
-                  // TODO replace with reject
-                  throw jsi::JSError(rt, batchResult.message);
+                  auto errorCtr = rt.global().getPropertyAsFunction(rt, "Error");
+                  auto error = errorCtr.callAsConstructor(rt, jsi::String::createFromUtf8(rt, batchResult.message));
+                  reject->asObject(rt).asFunction(rt).call(rt, error);
                 }
               });
         } catch (std::exception &exc) {
@@ -438,7 +439,7 @@ void install(jsi::Runtime &rt,
   auto load_file = HOSTFN("loadFile", 2) {
     if (sizeof(args) < 2) {
       throw std::runtime_error(
-          "[op-sqlite][loadFileAsync] Incorrect parameter count");
+          "[op-sqlite][loadFile] Incorrect parameter count");
       return {};
     }
 
@@ -463,7 +464,9 @@ void install(jsi::Runtime &rt,
                   res.setProperty(rt, "commands", jsi::Value(result.commands));
                   resolve->asObject(rt).asFunction(rt).call(rt, std::move(res));
                 } else {
-                  throw jsi::JSError(rt, result.message);
+                  auto errorCtr = rt.global().getPropertyAsFunction(rt, "Error");
+                  auto error = errorCtr.callAsConstructor(rt, jsi::String::createFromUtf8(rt, result.message));
+                  reject->asObject(rt).asFunction(rt).call(rt, error);
                 }
               });
         } catch (std::exception &exc) {

--- a/cpp/bridge.cpp
+++ b/cpp/bridge.cpp
@@ -257,7 +257,7 @@ BridgeResult opsqlite_execute_prepared_statement(
           // Intentionally left blank
 
         default:
-          row.values.push_back(JSVariant(NULL));
+          row.values.push_back(JSVariant(nullptr));
           break;
         }
         i++;

--- a/cpp/bridge.cpp
+++ b/cpp/bridge.cpp
@@ -445,7 +445,7 @@ opsqlite_execute(std::string const &dbName, std::string const &query,
             // Intentionally left blank
 
           default:
-            row.values.push_back(JSVariant(NULL));
+            row.values.push_back(JSVariant(nullptr));
             break;
           }
           i++;
@@ -617,7 +617,7 @@ opsqlite_execute_raw(std::string const &dbName, std::string const &query,
             // Intentionally left blank
 
           default:
-            row.push_back(JSVariant(NULL));
+            row.push_back(JSVariant(nullptr));
             break;
           }
           i++;

--- a/op-sqlite.podspec
+++ b/op-sqlite.podspec
@@ -28,6 +28,8 @@ Pod::Spec.new do |s|
 
   other_cflags = '-DSQLITE_DBCONFIG_ENABLE_LOAD_EXTENSION=1'
 
+  optimizedCflags = other_cflags + '$(inherited) -DSQLITE_DQS=0 -DSQLITE_DEFAULT_MEMSTATUS=0 -DSQLITE_DEFAULT_WAL_SYNCHRONOUS=1 -DSQLITE_LIKE_DOESNT_MATCH_BLOBS=1 -DSQLITE_MAX_EXPR_DEPTH=0 -DSQLITE_OMIT_DEPRECATED=1 -DSQLITE_OMIT_PROGRESS_CALLBACK=1 -DSQLITE_OMIT_SHARED_CACHE=1 -DSQLITE_USE_ALLOCA=1'
+
   xcconfig = {
     :GCC_PREPROCESSOR_DEFINITIONS => "HAVE_FULLFSYNC=1",
     :WARNING_CFLAGS => "-Wno-shorten-64-to-32 -Wno-comma -Wno-unreachable-code -Wno-conditional-uninitialized -Wno-deprecated-declarations",
@@ -43,7 +45,12 @@ Pod::Spec.new do |s|
 
   if ENV['OP_SQLITE_PERF'] == '1' then
     puts "OP-SQLITE performance mode enabled! 🚀\n"
-    xcconfig[:OTHER_CFLAGS] = other_cflags + '$(inherited) -DSQLITE_DQS=0 -DSQLITE_THREADSAFE=0 -DSQLITE_DEFAULT_MEMSTATUS=0 -DSQLITE_DEFAULT_WAL_SYNCHRONOUS=1 -DSQLITE_LIKE_DOESNT_MATCH_BLOBS=1 -DSQLITE_MAX_EXPR_DEPTH=0 -DSQLITE_OMIT_DEPRECATED=1 -DSQLITE_OMIT_PROGRESS_CALLBACK=1 -DSQLITE_OMIT_SHARED_CACHE=1 -DSQLITE_USE_ALLOCA=1'
+    xcconfig[:OTHER_CFLAGS] = optimizedCflags + ' -DSQLITE_THREADSAFE=0 '
+  end
+
+  if ENV['OP_SQLITE_PERF'] == '2' then
+    puts "OP-SQLITE performance mode enabled! 🚀\n"
+    xcconfig[:OTHER_CFLAGS] = optimizedCflags + ' -DSQLITE_THREADSAFE=1 '
   end
 
   s.pod_target_xcconfig = xcconfig

--- a/op-sqlite.podspec
+++ b/op-sqlite.podspec
@@ -49,7 +49,7 @@ Pod::Spec.new do |s|
   end
 
   if ENV['OP_SQLITE_PERF'] == '2' then
-    puts "OP-SQLITE performance mode enabled! 🚀\n"
+    puts "OP-SQLITE (thread safe) performance mode enabled! 🚀\n"
     xcconfig[:OTHER_CFLAGS] = optimizedCflags + ' -DSQLITE_THREADSAFE=1 '
   end
 


### PR DESCRIPTION
OP_SQLITE_PERF=1 disables thread safety, and the app crashes if used with async parallel methods.

Added OP_SQLITE_PERF=2 (as another optimization profile?) to support the other optimization flags and keep thread safety (via serialized mode).

Some minor fixes on async methods too, rejecting promises in case of SQL Errors instead of throwing errors to keep the a sane behavior.

Late added another fix that prevents the HostObjects to send null values on row properties. All null values (for any type of column) was being converted to zeroes. Fixed.

