### PR TITLE
SQLite upgrade to 3.45.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ yarn add @op-engineering/op-sqlite && npx pod-install
 
 OP-SQLite embeds the latest version of SQLite and provides a low-level API to execute SQL queries.
 
-**Current SQLite version: 3.44.0**
+**Current SQLite version: 3.45.1**
 
 Created by [@ospfranco](https://twitter.com/ospfranco). **Please consider sponsoring!**.
 

--- a/cpp/sqlite3.h
+++ b/cpp/sqlite3.h
@@ -32,7 +32,7 @@
 */
 #ifndef SQLITE3_H
 #define SQLITE3_H
-#include <stdarg.h> /* Needed for the definition of va_list */
+#include <stdarg.h>     /* Needed for the definition of va_list */
 
 /*
 ** Make sure we can call this stuff from C++.
@@ -40,6 +40,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
 
 /*
 ** Facilitate override of interface linkage and calling conventions.
@@ -68,25 +69,25 @@ extern "C" {
 ** that require non-default calling conventions.
 */
 #ifndef SQLITE_EXTERN
-#define SQLITE_EXTERN extern
+# define SQLITE_EXTERN extern
 #endif
 #ifndef SQLITE_API
-#define SQLITE_API
+# define SQLITE_API
 #endif
 #ifndef SQLITE_CDECL
-#define SQLITE_CDECL
+# define SQLITE_CDECL
 #endif
 #ifndef SQLITE_APICALL
-#define SQLITE_APICALL
+# define SQLITE_APICALL
 #endif
 #ifndef SQLITE_STDCALL
-#define SQLITE_STDCALL SQLITE_APICALL
+# define SQLITE_STDCALL SQLITE_APICALL
 #endif
 #ifndef SQLITE_CALLBACK
-#define SQLITE_CALLBACK
+# define SQLITE_CALLBACK
 #endif
 #ifndef SQLITE_SYSAPI
-#define SQLITE_SYSAPI
+# define SQLITE_SYSAPI
 #endif
 
 /*
@@ -109,10 +110,10 @@ extern "C" {
 ** Ensure these symbols were not defined by some previous header file.
 */
 #ifdef SQLITE_VERSION
-#undef SQLITE_VERSION
+# undef SQLITE_VERSION
 #endif
 #ifdef SQLITE_VERSION_NUMBER
-#undef SQLITE_VERSION_NUMBER
+# undef SQLITE_VERSION_NUMBER
 #endif
 
 /*
@@ -145,11 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION "3.44.0"
-#define SQLITE_VERSION_NUMBER 3044000
-#define SQLITE_SOURCE_ID                                                       \
-  "2023-11-01 11:23:50 "                                                       \
-  "17129ba1ff7f0daf37100ee82d507aef7827cf38de1866e2633096ae6ad81301"
+#define SQLITE_VERSION        "3.45.1"
+#define SQLITE_VERSION_NUMBER 3045001
+#define SQLITE_SOURCE_ID      "2024-01-30 16:01:20 e876e51a0ed5c5b3126f52e532044363a014bc594cfefa87ffb5b82257cc467a"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers
@@ -214,8 +213,8 @@ SQLITE_API int sqlite3_libversion_number(void);
 SQLITE_API int sqlite3_compileoption_used(const char *zOptName);
 SQLITE_API const char *sqlite3_compileoption_get(int N);
 #else
-#define sqlite3_compileoption_used(X) 0
-#define sqlite3_compileoption_get(X) ((void *)0)
+# define sqlite3_compileoption_used(X) 0
+# define sqlite3_compileoption_get(X)  ((void*)0)
 #endif
 
 /*
@@ -289,18 +288,18 @@ typedef struct sqlite3 sqlite3;
 ** between 0 and +18446744073709551615 inclusive.
 */
 #ifdef SQLITE_INT64_TYPE
-typedef SQLITE_INT64_TYPE sqlite_int64;
-#ifdef SQLITE_UINT64_TYPE
-typedef SQLITE_UINT64_TYPE sqlite_uint64;
-#else
-typedef unsigned SQLITE_INT64_TYPE sqlite_uint64;
-#endif
+  typedef SQLITE_INT64_TYPE sqlite_int64;
+# ifdef SQLITE_UINT64_TYPE
+    typedef SQLITE_UINT64_TYPE sqlite_uint64;
+# else
+    typedef unsigned SQLITE_INT64_TYPE sqlite_uint64;
+# endif
 #elif defined(_MSC_VER) || defined(__BORLANDC__)
-typedef __int64 sqlite_int64;
-typedef unsigned __int64 sqlite_uint64;
+  typedef __int64 sqlite_int64;
+  typedef unsigned __int64 sqlite_uint64;
 #else
-typedef long long int sqlite_int64;
-typedef unsigned long long int sqlite_uint64;
+  typedef long long int sqlite_int64;
+  typedef unsigned long long int sqlite_uint64;
 #endif
 typedef sqlite_int64 sqlite3_int64;
 typedef sqlite_uint64 sqlite3_uint64;
@@ -310,7 +309,7 @@ typedef sqlite_uint64 sqlite3_uint64;
 ** substitute integer for floating-point.
 */
 #ifdef SQLITE_OMIT_FLOATING_POINT
-#define double sqlite3_int64
+# define double sqlite3_int64
 #endif
 
 /*
@@ -351,15 +350,15 @@ typedef sqlite_uint64 sqlite3_uint64;
 ** ^Calling sqlite3_close() or sqlite3_close_v2() with a NULL pointer
 ** argument is a harmless no-op.
 */
-SQLITE_API int sqlite3_close(sqlite3 *);
-SQLITE_API int sqlite3_close_v2(sqlite3 *);
+SQLITE_API int sqlite3_close(sqlite3*);
+SQLITE_API int sqlite3_close_v2(sqlite3*);
 
 /*
 ** The type for a callback function.
 ** This is legacy and deprecated.  It is included for historical
 ** compatibility and is not documented.
 */
-typedef int (*sqlite3_callback)(void *, int, char **, char **);
+typedef int (*sqlite3_callback)(void*,int,char**, char**);
 
 /*
 ** CAPI3REF: One-Step Query Execution Interface
@@ -423,12 +422,12 @@ typedef int (*sqlite3_callback)(void *, int, char **, char **);
 **      the 2nd parameter of sqlite3_exec() while sqlite3_exec() is running.
 ** </ul>
 */
-SQLITE_API int sqlite3_exec(sqlite3 *,       /* An open database */
-                            const char *sql, /* SQL to be evaluated */
-                            int (*callback)(void *, int, char **,
-                                            char **), /* Callback function */
-                            void *,       /* 1st argument to callback */
-                            char **errmsg /* Error msg written here */
+SQLITE_API int sqlite3_exec(
+  sqlite3*,                                  /* An open database */
+  const char *sql,                           /* SQL to be evaluated */
+  int (*callback)(void*,int,char**,char**),  /* Callback function */
+  void *,                                    /* 1st argument to callback */
+  char **errmsg                              /* Error msg written here */
 );
 
 /*
@@ -442,38 +441,38 @@ SQLITE_API int sqlite3_exec(sqlite3 *,       /* An open database */
 **
 ** See also: [extended result code definitions]
 */
-#define SQLITE_OK 0 /* Successful result */
+#define SQLITE_OK           0   /* Successful result */
 /* beginning-of-error-codes */
-#define SQLITE_ERROR 1       /* Generic error */
-#define SQLITE_INTERNAL 2    /* Internal logic error in SQLite */
-#define SQLITE_PERM 3        /* Access permission denied */
-#define SQLITE_ABORT 4       /* Callback routine requested an abort */
-#define SQLITE_BUSY 5        /* The database file is locked */
-#define SQLITE_LOCKED 6      /* A table in the database is locked */
-#define SQLITE_NOMEM 7       /* A malloc() failed */
-#define SQLITE_READONLY 8    /* Attempt to write a readonly database */
-#define SQLITE_INTERRUPT 9   /* Operation terminated by sqlite3_interrupt()*/
-#define SQLITE_IOERR 10      /* Some kind of disk I/O error occurred */
-#define SQLITE_CORRUPT 11    /* The database disk image is malformed */
-#define SQLITE_NOTFOUND 12   /* Unknown opcode in sqlite3_file_control() */
-#define SQLITE_FULL 13       /* Insertion failed because database is full */
-#define SQLITE_CANTOPEN 14   /* Unable to open the database file */
-#define SQLITE_PROTOCOL 15   /* Database lock protocol error */
-#define SQLITE_EMPTY 16      /* Internal use only */
-#define SQLITE_SCHEMA 17     /* The database schema changed */
-#define SQLITE_TOOBIG 18     /* String or BLOB exceeds size limit */
-#define SQLITE_CONSTRAINT 19 /* Abort due to constraint violation */
-#define SQLITE_MISMATCH 20   /* Data type mismatch */
-#define SQLITE_MISUSE 21     /* Library used incorrectly */
-#define SQLITE_NOLFS 22      /* Uses OS features not supported on host */
-#define SQLITE_AUTH 23       /* Authorization denied */
-#define SQLITE_FORMAT 24     /* Not used */
-#define SQLITE_RANGE 25      /* 2nd parameter to sqlite3_bind out of range */
-#define SQLITE_NOTADB 26     /* File opened that is not a database file */
-#define SQLITE_NOTICE 27     /* Notifications from sqlite3_log() */
-#define SQLITE_WARNING 28    /* Warnings from sqlite3_log() */
-#define SQLITE_ROW 100       /* sqlite3_step() has another row ready */
-#define SQLITE_DONE 101      /* sqlite3_step() has finished executing */
+#define SQLITE_ERROR        1   /* Generic error */
+#define SQLITE_INTERNAL     2   /* Internal logic error in SQLite */
+#define SQLITE_PERM         3   /* Access permission denied */
+#define SQLITE_ABORT        4   /* Callback routine requested an abort */
+#define SQLITE_BUSY         5   /* The database file is locked */
+#define SQLITE_LOCKED       6   /* A table in the database is locked */
+#define SQLITE_NOMEM        7   /* A malloc() failed */
+#define SQLITE_READONLY     8   /* Attempt to write a readonly database */
+#define SQLITE_INTERRUPT    9   /* Operation terminated by sqlite3_interrupt()*/
+#define SQLITE_IOERR       10   /* Some kind of disk I/O error occurred */
+#define SQLITE_CORRUPT     11   /* The database disk image is malformed */
+#define SQLITE_NOTFOUND    12   /* Unknown opcode in sqlite3_file_control() */
+#define SQLITE_FULL        13   /* Insertion failed because database is full */
+#define SQLITE_CANTOPEN    14   /* Unable to open the database file */
+#define SQLITE_PROTOCOL    15   /* Database lock protocol error */
+#define SQLITE_EMPTY       16   /* Internal use only */
+#define SQLITE_SCHEMA      17   /* The database schema changed */
+#define SQLITE_TOOBIG      18   /* String or BLOB exceeds size limit */
+#define SQLITE_CONSTRAINT  19   /* Abort due to constraint violation */
+#define SQLITE_MISMATCH    20   /* Data type mismatch */
+#define SQLITE_MISUSE      21   /* Library used incorrectly */
+#define SQLITE_NOLFS       22   /* Uses OS features not supported on host */
+#define SQLITE_AUTH        23   /* Authorization denied */
+#define SQLITE_FORMAT      24   /* Not used */
+#define SQLITE_RANGE       25   /* 2nd parameter to sqlite3_bind out of range */
+#define SQLITE_NOTADB      26   /* File opened that is not a database file */
+#define SQLITE_NOTICE      27   /* Notifications from sqlite3_log() */
+#define SQLITE_WARNING     28   /* Warnings from sqlite3_log() */
+#define SQLITE_ROW         100  /* sqlite3_step() has another row ready */
+#define SQLITE_DONE        101  /* sqlite3_step() has finished executing */
 /* end-of-error-codes */
 
 /*
@@ -493,83 +492,83 @@ SQLITE_API int sqlite3_exec(sqlite3 *,       /* An open database */
 ** the most recent error can be obtained using
 ** [sqlite3_extended_errcode()].
 */
-#define SQLITE_ERROR_MISSING_COLLSEQ (SQLITE_ERROR | (1 << 8))
-#define SQLITE_ERROR_RETRY (SQLITE_ERROR | (2 << 8))
-#define SQLITE_ERROR_SNAPSHOT (SQLITE_ERROR | (3 << 8))
-#define SQLITE_IOERR_READ (SQLITE_IOERR | (1 << 8))
-#define SQLITE_IOERR_SHORT_READ (SQLITE_IOERR | (2 << 8))
-#define SQLITE_IOERR_WRITE (SQLITE_IOERR | (3 << 8))
-#define SQLITE_IOERR_FSYNC (SQLITE_IOERR | (4 << 8))
-#define SQLITE_IOERR_DIR_FSYNC (SQLITE_IOERR | (5 << 8))
-#define SQLITE_IOERR_TRUNCATE (SQLITE_IOERR | (6 << 8))
-#define SQLITE_IOERR_FSTAT (SQLITE_IOERR | (7 << 8))
-#define SQLITE_IOERR_UNLOCK (SQLITE_IOERR | (8 << 8))
-#define SQLITE_IOERR_RDLOCK (SQLITE_IOERR | (9 << 8))
-#define SQLITE_IOERR_DELETE (SQLITE_IOERR | (10 << 8))
-#define SQLITE_IOERR_BLOCKED (SQLITE_IOERR | (11 << 8))
-#define SQLITE_IOERR_NOMEM (SQLITE_IOERR | (12 << 8))
-#define SQLITE_IOERR_ACCESS (SQLITE_IOERR | (13 << 8))
-#define SQLITE_IOERR_CHECKRESERVEDLOCK (SQLITE_IOERR | (14 << 8))
-#define SQLITE_IOERR_LOCK (SQLITE_IOERR | (15 << 8))
-#define SQLITE_IOERR_CLOSE (SQLITE_IOERR | (16 << 8))
-#define SQLITE_IOERR_DIR_CLOSE (SQLITE_IOERR | (17 << 8))
-#define SQLITE_IOERR_SHMOPEN (SQLITE_IOERR | (18 << 8))
-#define SQLITE_IOERR_SHMSIZE (SQLITE_IOERR | (19 << 8))
-#define SQLITE_IOERR_SHMLOCK (SQLITE_IOERR | (20 << 8))
-#define SQLITE_IOERR_SHMMAP (SQLITE_IOERR | (21 << 8))
-#define SQLITE_IOERR_SEEK (SQLITE_IOERR | (22 << 8))
-#define SQLITE_IOERR_DELETE_NOENT (SQLITE_IOERR | (23 << 8))
-#define SQLITE_IOERR_MMAP (SQLITE_IOERR | (24 << 8))
-#define SQLITE_IOERR_GETTEMPPATH (SQLITE_IOERR | (25 << 8))
-#define SQLITE_IOERR_CONVPATH (SQLITE_IOERR | (26 << 8))
-#define SQLITE_IOERR_VNODE (SQLITE_IOERR | (27 << 8))
-#define SQLITE_IOERR_AUTH (SQLITE_IOERR | (28 << 8))
-#define SQLITE_IOERR_BEGIN_ATOMIC (SQLITE_IOERR | (29 << 8))
-#define SQLITE_IOERR_COMMIT_ATOMIC (SQLITE_IOERR | (30 << 8))
-#define SQLITE_IOERR_ROLLBACK_ATOMIC (SQLITE_IOERR | (31 << 8))
-#define SQLITE_IOERR_DATA (SQLITE_IOERR | (32 << 8))
-#define SQLITE_IOERR_CORRUPTFS (SQLITE_IOERR | (33 << 8))
-#define SQLITE_IOERR_IN_PAGE (SQLITE_IOERR | (34 << 8))
-#define SQLITE_LOCKED_SHAREDCACHE (SQLITE_LOCKED | (1 << 8))
-#define SQLITE_LOCKED_VTAB (SQLITE_LOCKED | (2 << 8))
-#define SQLITE_BUSY_RECOVERY (SQLITE_BUSY | (1 << 8))
-#define SQLITE_BUSY_SNAPSHOT (SQLITE_BUSY | (2 << 8))
-#define SQLITE_BUSY_TIMEOUT (SQLITE_BUSY | (3 << 8))
-#define SQLITE_CANTOPEN_NOTEMPDIR (SQLITE_CANTOPEN | (1 << 8))
-#define SQLITE_CANTOPEN_ISDIR (SQLITE_CANTOPEN | (2 << 8))
-#define SQLITE_CANTOPEN_FULLPATH (SQLITE_CANTOPEN | (3 << 8))
-#define SQLITE_CANTOPEN_CONVPATH (SQLITE_CANTOPEN | (4 << 8))
-#define SQLITE_CANTOPEN_DIRTYWAL (SQLITE_CANTOPEN | (5 << 8)) /* Not Used */
-#define SQLITE_CANTOPEN_SYMLINK (SQLITE_CANTOPEN | (6 << 8))
-#define SQLITE_CORRUPT_VTAB (SQLITE_CORRUPT | (1 << 8))
-#define SQLITE_CORRUPT_SEQUENCE (SQLITE_CORRUPT | (2 << 8))
-#define SQLITE_CORRUPT_INDEX (SQLITE_CORRUPT | (3 << 8))
-#define SQLITE_READONLY_RECOVERY (SQLITE_READONLY | (1 << 8))
-#define SQLITE_READONLY_CANTLOCK (SQLITE_READONLY | (2 << 8))
-#define SQLITE_READONLY_ROLLBACK (SQLITE_READONLY | (3 << 8))
-#define SQLITE_READONLY_DBMOVED (SQLITE_READONLY | (4 << 8))
-#define SQLITE_READONLY_CANTINIT (SQLITE_READONLY | (5 << 8))
-#define SQLITE_READONLY_DIRECTORY (SQLITE_READONLY | (6 << 8))
-#define SQLITE_ABORT_ROLLBACK (SQLITE_ABORT | (2 << 8))
-#define SQLITE_CONSTRAINT_CHECK (SQLITE_CONSTRAINT | (1 << 8))
-#define SQLITE_CONSTRAINT_COMMITHOOK (SQLITE_CONSTRAINT | (2 << 8))
-#define SQLITE_CONSTRAINT_FOREIGNKEY (SQLITE_CONSTRAINT | (3 << 8))
-#define SQLITE_CONSTRAINT_FUNCTION (SQLITE_CONSTRAINT | (4 << 8))
-#define SQLITE_CONSTRAINT_NOTNULL (SQLITE_CONSTRAINT | (5 << 8))
-#define SQLITE_CONSTRAINT_PRIMARYKEY (SQLITE_CONSTRAINT | (6 << 8))
-#define SQLITE_CONSTRAINT_TRIGGER (SQLITE_CONSTRAINT | (7 << 8))
-#define SQLITE_CONSTRAINT_UNIQUE (SQLITE_CONSTRAINT | (8 << 8))
-#define SQLITE_CONSTRAINT_VTAB (SQLITE_CONSTRAINT | (9 << 8))
-#define SQLITE_CONSTRAINT_ROWID (SQLITE_CONSTRAINT | (10 << 8))
-#define SQLITE_CONSTRAINT_PINNED (SQLITE_CONSTRAINT | (11 << 8))
-#define SQLITE_CONSTRAINT_DATATYPE (SQLITE_CONSTRAINT | (12 << 8))
-#define SQLITE_NOTICE_RECOVER_WAL (SQLITE_NOTICE | (1 << 8))
-#define SQLITE_NOTICE_RECOVER_ROLLBACK (SQLITE_NOTICE | (2 << 8))
-#define SQLITE_NOTICE_RBU (SQLITE_NOTICE | (3 << 8))
-#define SQLITE_WARNING_AUTOINDEX (SQLITE_WARNING | (1 << 8))
-#define SQLITE_AUTH_USER (SQLITE_AUTH | (1 << 8))
-#define SQLITE_OK_LOAD_PERMANENTLY (SQLITE_OK | (1 << 8))
-#define SQLITE_OK_SYMLINK (SQLITE_OK | (2 << 8)) /* internal use only */
+#define SQLITE_ERROR_MISSING_COLLSEQ   (SQLITE_ERROR | (1<<8))
+#define SQLITE_ERROR_RETRY             (SQLITE_ERROR | (2<<8))
+#define SQLITE_ERROR_SNAPSHOT          (SQLITE_ERROR | (3<<8))
+#define SQLITE_IOERR_READ              (SQLITE_IOERR | (1<<8))
+#define SQLITE_IOERR_SHORT_READ        (SQLITE_IOERR | (2<<8))
+#define SQLITE_IOERR_WRITE             (SQLITE_IOERR | (3<<8))
+#define SQLITE_IOERR_FSYNC             (SQLITE_IOERR | (4<<8))
+#define SQLITE_IOERR_DIR_FSYNC         (SQLITE_IOERR | (5<<8))
+#define SQLITE_IOERR_TRUNCATE          (SQLITE_IOERR | (6<<8))
+#define SQLITE_IOERR_FSTAT             (SQLITE_IOERR | (7<<8))
+#define SQLITE_IOERR_UNLOCK            (SQLITE_IOERR | (8<<8))
+#define SQLITE_IOERR_RDLOCK            (SQLITE_IOERR | (9<<8))
+#define SQLITE_IOERR_DELETE            (SQLITE_IOERR | (10<<8))
+#define SQLITE_IOERR_BLOCKED           (SQLITE_IOERR | (11<<8))
+#define SQLITE_IOERR_NOMEM             (SQLITE_IOERR | (12<<8))
+#define SQLITE_IOERR_ACCESS            (SQLITE_IOERR | (13<<8))
+#define SQLITE_IOERR_CHECKRESERVEDLOCK (SQLITE_IOERR | (14<<8))
+#define SQLITE_IOERR_LOCK              (SQLITE_IOERR | (15<<8))
+#define SQLITE_IOERR_CLOSE             (SQLITE_IOERR | (16<<8))
+#define SQLITE_IOERR_DIR_CLOSE         (SQLITE_IOERR | (17<<8))
+#define SQLITE_IOERR_SHMOPEN           (SQLITE_IOERR | (18<<8))
+#define SQLITE_IOERR_SHMSIZE           (SQLITE_IOERR | (19<<8))
+#define SQLITE_IOERR_SHMLOCK           (SQLITE_IOERR | (20<<8))
+#define SQLITE_IOERR_SHMMAP            (SQLITE_IOERR | (21<<8))
+#define SQLITE_IOERR_SEEK              (SQLITE_IOERR | (22<<8))
+#define SQLITE_IOERR_DELETE_NOENT      (SQLITE_IOERR | (23<<8))
+#define SQLITE_IOERR_MMAP              (SQLITE_IOERR | (24<<8))
+#define SQLITE_IOERR_GETTEMPPATH       (SQLITE_IOERR | (25<<8))
+#define SQLITE_IOERR_CONVPATH          (SQLITE_IOERR | (26<<8))
+#define SQLITE_IOERR_VNODE             (SQLITE_IOERR | (27<<8))
+#define SQLITE_IOERR_AUTH              (SQLITE_IOERR | (28<<8))
+#define SQLITE_IOERR_BEGIN_ATOMIC      (SQLITE_IOERR | (29<<8))
+#define SQLITE_IOERR_COMMIT_ATOMIC     (SQLITE_IOERR | (30<<8))
+#define SQLITE_IOERR_ROLLBACK_ATOMIC   (SQLITE_IOERR | (31<<8))
+#define SQLITE_IOERR_DATA              (SQLITE_IOERR | (32<<8))
+#define SQLITE_IOERR_CORRUPTFS         (SQLITE_IOERR | (33<<8))
+#define SQLITE_IOERR_IN_PAGE           (SQLITE_IOERR | (34<<8))
+#define SQLITE_LOCKED_SHAREDCACHE      (SQLITE_LOCKED |  (1<<8))
+#define SQLITE_LOCKED_VTAB             (SQLITE_LOCKED |  (2<<8))
+#define SQLITE_BUSY_RECOVERY           (SQLITE_BUSY   |  (1<<8))
+#define SQLITE_BUSY_SNAPSHOT           (SQLITE_BUSY   |  (2<<8))
+#define SQLITE_BUSY_TIMEOUT            (SQLITE_BUSY   |  (3<<8))
+#define SQLITE_CANTOPEN_NOTEMPDIR      (SQLITE_CANTOPEN | (1<<8))
+#define SQLITE_CANTOPEN_ISDIR          (SQLITE_CANTOPEN | (2<<8))
+#define SQLITE_CANTOPEN_FULLPATH       (SQLITE_CANTOPEN | (3<<8))
+#define SQLITE_CANTOPEN_CONVPATH       (SQLITE_CANTOPEN | (4<<8))
+#define SQLITE_CANTOPEN_DIRTYWAL       (SQLITE_CANTOPEN | (5<<8)) /* Not Used */
+#define SQLITE_CANTOPEN_SYMLINK        (SQLITE_CANTOPEN | (6<<8))
+#define SQLITE_CORRUPT_VTAB            (SQLITE_CORRUPT | (1<<8))
+#define SQLITE_CORRUPT_SEQUENCE        (SQLITE_CORRUPT | (2<<8))
+#define SQLITE_CORRUPT_INDEX           (SQLITE_CORRUPT | (3<<8))
+#define SQLITE_READONLY_RECOVERY       (SQLITE_READONLY | (1<<8))
+#define SQLITE_READONLY_CANTLOCK       (SQLITE_READONLY | (2<<8))
+#define SQLITE_READONLY_ROLLBACK       (SQLITE_READONLY | (3<<8))
+#define SQLITE_READONLY_DBMOVED        (SQLITE_READONLY | (4<<8))
+#define SQLITE_READONLY_CANTINIT       (SQLITE_READONLY | (5<<8))
+#define SQLITE_READONLY_DIRECTORY      (SQLITE_READONLY | (6<<8))
+#define SQLITE_ABORT_ROLLBACK          (SQLITE_ABORT | (2<<8))
+#define SQLITE_CONSTRAINT_CHECK        (SQLITE_CONSTRAINT | (1<<8))
+#define SQLITE_CONSTRAINT_COMMITHOOK   (SQLITE_CONSTRAINT | (2<<8))
+#define SQLITE_CONSTRAINT_FOREIGNKEY   (SQLITE_CONSTRAINT | (3<<8))
+#define SQLITE_CONSTRAINT_FUNCTION     (SQLITE_CONSTRAINT | (4<<8))
+#define SQLITE_CONSTRAINT_NOTNULL      (SQLITE_CONSTRAINT | (5<<8))
+#define SQLITE_CONSTRAINT_PRIMARYKEY   (SQLITE_CONSTRAINT | (6<<8))
+#define SQLITE_CONSTRAINT_TRIGGER      (SQLITE_CONSTRAINT | (7<<8))
+#define SQLITE_CONSTRAINT_UNIQUE       (SQLITE_CONSTRAINT | (8<<8))
+#define SQLITE_CONSTRAINT_VTAB         (SQLITE_CONSTRAINT | (9<<8))
+#define SQLITE_CONSTRAINT_ROWID        (SQLITE_CONSTRAINT |(10<<8))
+#define SQLITE_CONSTRAINT_PINNED       (SQLITE_CONSTRAINT |(11<<8))
+#define SQLITE_CONSTRAINT_DATATYPE     (SQLITE_CONSTRAINT |(12<<8))
+#define SQLITE_NOTICE_RECOVER_WAL      (SQLITE_NOTICE | (1<<8))
+#define SQLITE_NOTICE_RECOVER_ROLLBACK (SQLITE_NOTICE | (2<<8))
+#define SQLITE_NOTICE_RBU              (SQLITE_NOTICE | (3<<8))
+#define SQLITE_WARNING_AUTOINDEX       (SQLITE_WARNING | (1<<8))
+#define SQLITE_AUTH_USER               (SQLITE_AUTH | (1<<8))
+#define SQLITE_OK_LOAD_PERMANENTLY     (SQLITE_OK | (1<<8))
+#define SQLITE_OK_SYMLINK              (SQLITE_OK | (2<<8)) /* internal use only */
 
 /*
 ** CAPI3REF: Flags For File Open Operations
@@ -591,32 +590,33 @@ SQLITE_API int sqlite3_exec(sqlite3 *,       /* An open database */
 ** [sqlite3_open_v2()] has historically be a no-op and might become an
 ** error in future versions of SQLite.
 */
-#define SQLITE_OPEN_READONLY 0x00000001      /* Ok for sqlite3_open_v2() */
-#define SQLITE_OPEN_READWRITE 0x00000002     /* Ok for sqlite3_open_v2() */
-#define SQLITE_OPEN_CREATE 0x00000004        /* Ok for sqlite3_open_v2() */
-#define SQLITE_OPEN_DELETEONCLOSE 0x00000008 /* VFS only */
-#define SQLITE_OPEN_EXCLUSIVE 0x00000010     /* VFS only */
-#define SQLITE_OPEN_AUTOPROXY 0x00000020     /* VFS only */
-#define SQLITE_OPEN_URI 0x00000040           /* Ok for sqlite3_open_v2() */
-#define SQLITE_OPEN_MEMORY 0x00000080        /* Ok for sqlite3_open_v2() */
-#define SQLITE_OPEN_MAIN_DB 0x00000100       /* VFS only */
-#define SQLITE_OPEN_TEMP_DB 0x00000200       /* VFS only */
-#define SQLITE_OPEN_TRANSIENT_DB 0x00000400  /* VFS only */
-#define SQLITE_OPEN_MAIN_JOURNAL 0x00000800  /* VFS only */
-#define SQLITE_OPEN_TEMP_JOURNAL 0x00001000  /* VFS only */
-#define SQLITE_OPEN_SUBJOURNAL 0x00002000    /* VFS only */
-#define SQLITE_OPEN_SUPER_JOURNAL 0x00004000 /* VFS only */
-#define SQLITE_OPEN_NOMUTEX 0x00008000       /* Ok for sqlite3_open_v2() */
-#define SQLITE_OPEN_FULLMUTEX 0x00010000     /* Ok for sqlite3_open_v2() */
-#define SQLITE_OPEN_SHAREDCACHE 0x00020000   /* Ok for sqlite3_open_v2() */
-#define SQLITE_OPEN_PRIVATECACHE 0x00040000  /* Ok for sqlite3_open_v2() */
-#define SQLITE_OPEN_WAL 0x00080000           /* VFS only */
-#define SQLITE_OPEN_NOFOLLOW 0x01000000      /* Ok for sqlite3_open_v2() */
-#define SQLITE_OPEN_EXRESCODE 0x02000000     /* Extended result codes */
+#define SQLITE_OPEN_READONLY         0x00000001  /* Ok for sqlite3_open_v2() */
+#define SQLITE_OPEN_READWRITE        0x00000002  /* Ok for sqlite3_open_v2() */
+#define SQLITE_OPEN_CREATE           0x00000004  /* Ok for sqlite3_open_v2() */
+#define SQLITE_OPEN_DELETEONCLOSE    0x00000008  /* VFS only */
+#define SQLITE_OPEN_EXCLUSIVE        0x00000010  /* VFS only */
+#define SQLITE_OPEN_AUTOPROXY        0x00000020  /* VFS only */
+#define SQLITE_OPEN_URI              0x00000040  /* Ok for sqlite3_open_v2() */
+#define SQLITE_OPEN_MEMORY           0x00000080  /* Ok for sqlite3_open_v2() */
+#define SQLITE_OPEN_MAIN_DB          0x00000100  /* VFS only */
+#define SQLITE_OPEN_TEMP_DB          0x00000200  /* VFS only */
+#define SQLITE_OPEN_TRANSIENT_DB     0x00000400  /* VFS only */
+#define SQLITE_OPEN_MAIN_JOURNAL     0x00000800  /* VFS only */
+#define SQLITE_OPEN_TEMP_JOURNAL     0x00001000  /* VFS only */
+#define SQLITE_OPEN_SUBJOURNAL       0x00002000  /* VFS only */
+#define SQLITE_OPEN_SUPER_JOURNAL    0x00004000  /* VFS only */
+#define SQLITE_OPEN_NOMUTEX          0x00008000  /* Ok for sqlite3_open_v2() */
+#define SQLITE_OPEN_FULLMUTEX        0x00010000  /* Ok for sqlite3_open_v2() */
+#define SQLITE_OPEN_SHAREDCACHE      0x00020000  /* Ok for sqlite3_open_v2() */
+#define SQLITE_OPEN_PRIVATECACHE     0x00040000  /* Ok for sqlite3_open_v2() */
+#define SQLITE_OPEN_WAL              0x00080000  /* VFS only */
+#define SQLITE_OPEN_NOFOLLOW         0x01000000  /* Ok for sqlite3_open_v2() */
+#define SQLITE_OPEN_EXRESCODE        0x02000000  /* Extended result codes */
 
 /* Reserved:                         0x00F00000 */
 /* Legacy compatibility: */
-#define SQLITE_OPEN_MASTER_JOURNAL 0x00004000 /* VFS only */
+#define SQLITE_OPEN_MASTER_JOURNAL   0x00004000  /* VFS only */
+
 
 /*
 ** CAPI3REF: Device Characteristics
@@ -651,21 +651,21 @@ SQLITE_API int sqlite3_exec(sqlite3 *,       /* An open database */
 ** write operations are bracketed by [SQLITE_FCNTL_BEGIN_ATOMIC_WRITE] and
 ** [SQLITE_FCNTL_COMMIT_ATOMIC_WRITE].
 */
-#define SQLITE_IOCAP_ATOMIC 0x00000001
-#define SQLITE_IOCAP_ATOMIC512 0x00000002
-#define SQLITE_IOCAP_ATOMIC1K 0x00000004
-#define SQLITE_IOCAP_ATOMIC2K 0x00000008
-#define SQLITE_IOCAP_ATOMIC4K 0x00000010
-#define SQLITE_IOCAP_ATOMIC8K 0x00000020
-#define SQLITE_IOCAP_ATOMIC16K 0x00000040
-#define SQLITE_IOCAP_ATOMIC32K 0x00000080
-#define SQLITE_IOCAP_ATOMIC64K 0x00000100
-#define SQLITE_IOCAP_SAFE_APPEND 0x00000200
-#define SQLITE_IOCAP_SEQUENTIAL 0x00000400
-#define SQLITE_IOCAP_UNDELETABLE_WHEN_OPEN 0x00000800
-#define SQLITE_IOCAP_POWERSAFE_OVERWRITE 0x00001000
-#define SQLITE_IOCAP_IMMUTABLE 0x00002000
-#define SQLITE_IOCAP_BATCH_ATOMIC 0x00004000
+#define SQLITE_IOCAP_ATOMIC                 0x00000001
+#define SQLITE_IOCAP_ATOMIC512              0x00000002
+#define SQLITE_IOCAP_ATOMIC1K               0x00000004
+#define SQLITE_IOCAP_ATOMIC2K               0x00000008
+#define SQLITE_IOCAP_ATOMIC4K               0x00000010
+#define SQLITE_IOCAP_ATOMIC8K               0x00000020
+#define SQLITE_IOCAP_ATOMIC16K              0x00000040
+#define SQLITE_IOCAP_ATOMIC32K              0x00000080
+#define SQLITE_IOCAP_ATOMIC64K              0x00000100
+#define SQLITE_IOCAP_SAFE_APPEND            0x00000200
+#define SQLITE_IOCAP_SEQUENTIAL             0x00000400
+#define SQLITE_IOCAP_UNDELETABLE_WHEN_OPEN  0x00000800
+#define SQLITE_IOCAP_POWERSAFE_OVERWRITE    0x00001000
+#define SQLITE_IOCAP_IMMUTABLE              0x00002000
+#define SQLITE_IOCAP_BATCH_ATOMIC           0x00004000
 
 /*
 ** CAPI3REF: File Locking Levels
@@ -678,11 +678,11 @@ SQLITE_API int sqlite3_exec(sqlite3 *,       /* An open database */
 ** The argument to xLock() is always SHARED or higher.  The argument to
 ** xUnlock is either SHARED or NONE.
 */
-#define SQLITE_LOCK_NONE 0      /* xUnlock() only */
-#define SQLITE_LOCK_SHARED 1    /* xLock() or xUnlock() */
-#define SQLITE_LOCK_RESERVED 2  /* xLock() only */
-#define SQLITE_LOCK_PENDING 3   /* xLock() only */
-#define SQLITE_LOCK_EXCLUSIVE 4 /* xLock() only */
+#define SQLITE_LOCK_NONE          0       /* xUnlock() only */
+#define SQLITE_LOCK_SHARED        1       /* xLock() or xUnlock() */
+#define SQLITE_LOCK_RESERVED      2       /* xLock() only */
+#define SQLITE_LOCK_PENDING       3       /* xLock() only */
+#define SQLITE_LOCK_EXCLUSIVE     4       /* xLock() only */
 
 /*
 ** CAPI3REF: Synchronization Type Flags
@@ -710,9 +710,9 @@ SQLITE_API int sqlite3_exec(sqlite3 *,       /* An open database */
 ** operating systems natively supported by SQLite, only Mac OSX
 ** cares about the difference.)
 */
-#define SQLITE_SYNC_NORMAL 0x00002
-#define SQLITE_SYNC_FULL 0x00003
-#define SQLITE_SYNC_DATAONLY 0x00010
+#define SQLITE_SYNC_NORMAL        0x00002
+#define SQLITE_SYNC_FULL          0x00003
+#define SQLITE_SYNC_DATAONLY      0x00010
 
 /*
 ** CAPI3REF: OS Interface Open File Handle
@@ -727,7 +727,7 @@ SQLITE_API int sqlite3_exec(sqlite3 *,       /* An open database */
 */
 typedef struct sqlite3_file sqlite3_file;
 struct sqlite3_file {
-  const struct sqlite3_io_methods *pMethods; /* Methods for an open file */
+  const struct sqlite3_io_methods *pMethods;  /* Methods for an open file */
 };
 
 /*
@@ -834,26 +834,26 @@ struct sqlite3_file {
 typedef struct sqlite3_io_methods sqlite3_io_methods;
 struct sqlite3_io_methods {
   int iVersion;
-  int (*xClose)(sqlite3_file *);
-  int (*xRead)(sqlite3_file *, void *, int iAmt, sqlite3_int64 iOfst);
-  int (*xWrite)(sqlite3_file *, const void *, int iAmt, sqlite3_int64 iOfst);
-  int (*xTruncate)(sqlite3_file *, sqlite3_int64 size);
-  int (*xSync)(sqlite3_file *, int flags);
-  int (*xFileSize)(sqlite3_file *, sqlite3_int64 *pSize);
-  int (*xLock)(sqlite3_file *, int);
-  int (*xUnlock)(sqlite3_file *, int);
-  int (*xCheckReservedLock)(sqlite3_file *, int *pResOut);
-  int (*xFileControl)(sqlite3_file *, int op, void *pArg);
-  int (*xSectorSize)(sqlite3_file *);
-  int (*xDeviceCharacteristics)(sqlite3_file *);
+  int (*xClose)(sqlite3_file*);
+  int (*xRead)(sqlite3_file*, void*, int iAmt, sqlite3_int64 iOfst);
+  int (*xWrite)(sqlite3_file*, const void*, int iAmt, sqlite3_int64 iOfst);
+  int (*xTruncate)(sqlite3_file*, sqlite3_int64 size);
+  int (*xSync)(sqlite3_file*, int flags);
+  int (*xFileSize)(sqlite3_file*, sqlite3_int64 *pSize);
+  int (*xLock)(sqlite3_file*, int);
+  int (*xUnlock)(sqlite3_file*, int);
+  int (*xCheckReservedLock)(sqlite3_file*, int *pResOut);
+  int (*xFileControl)(sqlite3_file*, int op, void *pArg);
+  int (*xSectorSize)(sqlite3_file*);
+  int (*xDeviceCharacteristics)(sqlite3_file*);
   /* Methods above are valid for version 1 */
-  int (*xShmMap)(sqlite3_file *, int iPg, int pgsz, int, void volatile **);
-  int (*xShmLock)(sqlite3_file *, int offset, int n, int flags);
-  void (*xShmBarrier)(sqlite3_file *);
-  int (*xShmUnmap)(sqlite3_file *, int deleteFlag);
+  int (*xShmMap)(sqlite3_file*, int iPg, int pgsz, int, void volatile**);
+  int (*xShmLock)(sqlite3_file*, int offset, int n, int flags);
+  void (*xShmBarrier)(sqlite3_file*);
+  int (*xShmUnmap)(sqlite3_file*, int deleteFlag);
   /* Methods above are valid for version 2 */
-  int (*xFetch)(sqlite3_file *, sqlite3_int64 iOfst, int iAmt, void **pp);
-  int (*xUnfetch)(sqlite3_file *, sqlite3_int64 iOfst, void *p);
+  int (*xFetch)(sqlite3_file*, sqlite3_int64 iOfst, int iAmt, void **pp);
+  int (*xUnfetch)(sqlite3_file*, sqlite3_int64 iOfst, void *p);
   /* Methods above are valid for version 3 */
   /* Additional methods may be added in future releases */
 };
@@ -1201,52 +1201,53 @@ struct sqlite3_io_methods {
 ** transaction, or if the db is a temp-db, this opcode is a no-op, not an error.
 ** </ul>
 */
-#define SQLITE_FCNTL_LOCKSTATE 1
-#define SQLITE_FCNTL_GET_LOCKPROXYFILE 2
-#define SQLITE_FCNTL_SET_LOCKPROXYFILE 3
-#define SQLITE_FCNTL_LAST_ERRNO 4
-#define SQLITE_FCNTL_SIZE_HINT 5
-#define SQLITE_FCNTL_CHUNK_SIZE 6
-#define SQLITE_FCNTL_FILE_POINTER 7
-#define SQLITE_FCNTL_SYNC_OMITTED 8
-#define SQLITE_FCNTL_WIN32_AV_RETRY 9
-#define SQLITE_FCNTL_PERSIST_WAL 10
-#define SQLITE_FCNTL_OVERWRITE 11
-#define SQLITE_FCNTL_VFSNAME 12
-#define SQLITE_FCNTL_POWERSAFE_OVERWRITE 13
-#define SQLITE_FCNTL_PRAGMA 14
-#define SQLITE_FCNTL_BUSYHANDLER 15
-#define SQLITE_FCNTL_TEMPFILENAME 16
-#define SQLITE_FCNTL_MMAP_SIZE 18
-#define SQLITE_FCNTL_TRACE 19
-#define SQLITE_FCNTL_HAS_MOVED 20
-#define SQLITE_FCNTL_SYNC 21
-#define SQLITE_FCNTL_COMMIT_PHASETWO 22
-#define SQLITE_FCNTL_WIN32_SET_HANDLE 23
-#define SQLITE_FCNTL_WAL_BLOCK 24
-#define SQLITE_FCNTL_ZIPVFS 25
-#define SQLITE_FCNTL_RBU 26
-#define SQLITE_FCNTL_VFS_POINTER 27
-#define SQLITE_FCNTL_JOURNAL_POINTER 28
-#define SQLITE_FCNTL_WIN32_GET_HANDLE 29
-#define SQLITE_FCNTL_PDB 30
-#define SQLITE_FCNTL_BEGIN_ATOMIC_WRITE 31
-#define SQLITE_FCNTL_COMMIT_ATOMIC_WRITE 32
-#define SQLITE_FCNTL_ROLLBACK_ATOMIC_WRITE 33
-#define SQLITE_FCNTL_LOCK_TIMEOUT 34
-#define SQLITE_FCNTL_DATA_VERSION 35
-#define SQLITE_FCNTL_SIZE_LIMIT 36
-#define SQLITE_FCNTL_CKPT_DONE 37
-#define SQLITE_FCNTL_RESERVE_BYTES 38
-#define SQLITE_FCNTL_CKPT_START 39
-#define SQLITE_FCNTL_EXTERNAL_READER 40
-#define SQLITE_FCNTL_CKSM_FILE 41
-#define SQLITE_FCNTL_RESET_CACHE 42
+#define SQLITE_FCNTL_LOCKSTATE               1
+#define SQLITE_FCNTL_GET_LOCKPROXYFILE       2
+#define SQLITE_FCNTL_SET_LOCKPROXYFILE       3
+#define SQLITE_FCNTL_LAST_ERRNO              4
+#define SQLITE_FCNTL_SIZE_HINT               5
+#define SQLITE_FCNTL_CHUNK_SIZE              6
+#define SQLITE_FCNTL_FILE_POINTER            7
+#define SQLITE_FCNTL_SYNC_OMITTED            8
+#define SQLITE_FCNTL_WIN32_AV_RETRY          9
+#define SQLITE_FCNTL_PERSIST_WAL            10
+#define SQLITE_FCNTL_OVERWRITE              11
+#define SQLITE_FCNTL_VFSNAME                12
+#define SQLITE_FCNTL_POWERSAFE_OVERWRITE    13
+#define SQLITE_FCNTL_PRAGMA                 14
+#define SQLITE_FCNTL_BUSYHANDLER            15
+#define SQLITE_FCNTL_TEMPFILENAME           16
+#define SQLITE_FCNTL_MMAP_SIZE              18
+#define SQLITE_FCNTL_TRACE                  19
+#define SQLITE_FCNTL_HAS_MOVED              20
+#define SQLITE_FCNTL_SYNC                   21
+#define SQLITE_FCNTL_COMMIT_PHASETWO        22
+#define SQLITE_FCNTL_WIN32_SET_HANDLE       23
+#define SQLITE_FCNTL_WAL_BLOCK              24
+#define SQLITE_FCNTL_ZIPVFS                 25
+#define SQLITE_FCNTL_RBU                    26
+#define SQLITE_FCNTL_VFS_POINTER            27
+#define SQLITE_FCNTL_JOURNAL_POINTER        28
+#define SQLITE_FCNTL_WIN32_GET_HANDLE       29
+#define SQLITE_FCNTL_PDB                    30
+#define SQLITE_FCNTL_BEGIN_ATOMIC_WRITE     31
+#define SQLITE_FCNTL_COMMIT_ATOMIC_WRITE    32
+#define SQLITE_FCNTL_ROLLBACK_ATOMIC_WRITE  33
+#define SQLITE_FCNTL_LOCK_TIMEOUT           34
+#define SQLITE_FCNTL_DATA_VERSION           35
+#define SQLITE_FCNTL_SIZE_LIMIT             36
+#define SQLITE_FCNTL_CKPT_DONE              37
+#define SQLITE_FCNTL_RESERVE_BYTES          38
+#define SQLITE_FCNTL_CKPT_START             39
+#define SQLITE_FCNTL_EXTERNAL_READER        40
+#define SQLITE_FCNTL_CKSM_FILE              41
+#define SQLITE_FCNTL_RESET_CACHE            42
 
 /* deprecated names */
-#define SQLITE_GET_LOCKPROXYFILE SQLITE_FCNTL_GET_LOCKPROXYFILE
-#define SQLITE_SET_LOCKPROXYFILE SQLITE_FCNTL_SET_LOCKPROXYFILE
-#define SQLITE_LAST_ERRNO SQLITE_FCNTL_LAST_ERRNO
+#define SQLITE_GET_LOCKPROXYFILE      SQLITE_FCNTL_GET_LOCKPROXYFILE
+#define SQLITE_SET_LOCKPROXYFILE      SQLITE_FCNTL_SET_LOCKPROXYFILE
+#define SQLITE_LAST_ERRNO             SQLITE_FCNTL_LAST_ERRNO
+
 
 /*
 ** CAPI3REF: Mutex Handle
@@ -1462,37 +1463,37 @@ typedef const char *sqlite3_filename;
 typedef struct sqlite3_vfs sqlite3_vfs;
 typedef void (*sqlite3_syscall_ptr)(void);
 struct sqlite3_vfs {
-  int iVersion;       /* Structure version number (currently 3) */
-  int szOsFile;       /* Size of subclassed sqlite3_file */
-  int mxPathname;     /* Maximum file pathname length */
-  sqlite3_vfs *pNext; /* Next registered VFS */
-  const char *zName;  /* Name of this virtual file system */
-  void *pAppData;     /* Pointer to application-specific data */
-  int (*xOpen)(sqlite3_vfs *, sqlite3_filename zName, sqlite3_file *, int flags,
-               int *pOutFlags);
-  int (*xDelete)(sqlite3_vfs *, const char *zName, int syncDir);
-  int (*xAccess)(sqlite3_vfs *, const char *zName, int flags, int *pResOut);
-  int (*xFullPathname)(sqlite3_vfs *, const char *zName, int nOut, char *zOut);
-  void *(*xDlOpen)(sqlite3_vfs *, const char *zFilename);
-  void (*xDlError)(sqlite3_vfs *, int nByte, char *zErrMsg);
-  void (*(*xDlSym)(sqlite3_vfs *, void *, const char *zSymbol))(void);
-  void (*xDlClose)(sqlite3_vfs *, void *);
-  int (*xRandomness)(sqlite3_vfs *, int nByte, char *zOut);
-  int (*xSleep)(sqlite3_vfs *, int microseconds);
-  int (*xCurrentTime)(sqlite3_vfs *, double *);
-  int (*xGetLastError)(sqlite3_vfs *, int, char *);
+  int iVersion;            /* Structure version number (currently 3) */
+  int szOsFile;            /* Size of subclassed sqlite3_file */
+  int mxPathname;          /* Maximum file pathname length */
+  sqlite3_vfs *pNext;      /* Next registered VFS */
+  const char *zName;       /* Name of this virtual file system */
+  void *pAppData;          /* Pointer to application-specific data */
+  int (*xOpen)(sqlite3_vfs*, sqlite3_filename zName, sqlite3_file*,
+               int flags, int *pOutFlags);
+  int (*xDelete)(sqlite3_vfs*, const char *zName, int syncDir);
+  int (*xAccess)(sqlite3_vfs*, const char *zName, int flags, int *pResOut);
+  int (*xFullPathname)(sqlite3_vfs*, const char *zName, int nOut, char *zOut);
+  void *(*xDlOpen)(sqlite3_vfs*, const char *zFilename);
+  void (*xDlError)(sqlite3_vfs*, int nByte, char *zErrMsg);
+  void (*(*xDlSym)(sqlite3_vfs*,void*, const char *zSymbol))(void);
+  void (*xDlClose)(sqlite3_vfs*, void*);
+  int (*xRandomness)(sqlite3_vfs*, int nByte, char *zOut);
+  int (*xSleep)(sqlite3_vfs*, int microseconds);
+  int (*xCurrentTime)(sqlite3_vfs*, double*);
+  int (*xGetLastError)(sqlite3_vfs*, int, char *);
   /*
   ** The methods above are in version 1 of the sqlite_vfs object
   ** definition.  Those that follow are added in version 2 or later
   */
-  int (*xCurrentTimeInt64)(sqlite3_vfs *, sqlite3_int64 *);
+  int (*xCurrentTimeInt64)(sqlite3_vfs*, sqlite3_int64*);
   /*
   ** The methods above are in versions 1 and 2 of the sqlite_vfs object.
   ** Those below are for version 3 and greater.
   */
-  int (*xSetSystemCall)(sqlite3_vfs *, const char *zName, sqlite3_syscall_ptr);
-  sqlite3_syscall_ptr (*xGetSystemCall)(sqlite3_vfs *, const char *zName);
-  const char *(*xNextSystemCall)(sqlite3_vfs *, const char *zName);
+  int (*xSetSystemCall)(sqlite3_vfs*, const char *zName, sqlite3_syscall_ptr);
+  sqlite3_syscall_ptr (*xGetSystemCall)(sqlite3_vfs*, const char *zName);
+  const char *(*xNextSystemCall)(sqlite3_vfs*, const char *zName);
   /*
   ** The methods above are in versions 1 through 3 of the sqlite_vfs object.
   ** New fields may be appended in future versions.  The iVersion
@@ -1520,9 +1521,9 @@ struct sqlite3_vfs {
 ** currently unused, though it might be used in a future release of
 ** SQLite.
 */
-#define SQLITE_ACCESS_EXISTS 0
-#define SQLITE_ACCESS_READWRITE 1 /* Used by PRAGMA temp_store_directory */
-#define SQLITE_ACCESS_READ 2      /* Unused */
+#define SQLITE_ACCESS_EXISTS    0
+#define SQLITE_ACCESS_READWRITE 1   /* Used by PRAGMA temp_store_directory */
+#define SQLITE_ACCESS_READ      2   /* Unused */
 
 /*
 ** CAPI3REF: Flags for the xShmLock VFS method
@@ -1546,10 +1547,10 @@ struct sqlite3_vfs {
 ** between unlocked and EXCLUSIVE.  It cannot transition between SHARED
 ** and EXCLUSIVE.
 */
-#define SQLITE_SHM_UNLOCK 1
-#define SQLITE_SHM_LOCK 2
-#define SQLITE_SHM_SHARED 4
-#define SQLITE_SHM_EXCLUSIVE 8
+#define SQLITE_SHM_UNLOCK       1
+#define SQLITE_SHM_LOCK         2
+#define SQLITE_SHM_SHARED       4
+#define SQLITE_SHM_EXCLUSIVE    8
 
 /*
 ** CAPI3REF: Maximum xShmLock index
@@ -1559,7 +1560,8 @@ struct sqlite3_vfs {
 ** The SQLite core will never attempt to acquire or release a
 ** lock outside of this range
 */
-#define SQLITE_SHM_NLOCK 8
+#define SQLITE_SHM_NLOCK        8
+
 
 /*
 ** CAPI3REF: Initialize The SQLite Library
@@ -1667,8 +1669,7 @@ SQLITE_API int sqlite3_os_end(void);
 ** are called "anytime configuration options".
 ** ^If sqlite3_config() is called after [sqlite3_initialize()] and before
 ** [sqlite3_shutdown()] with a first argument that is not an anytime
-** configuration option, then the sqlite3_config() call will return
-*SQLITE_MISUSE.
+** configuration option, then the sqlite3_config() call will return SQLITE_MISUSE.
 ** Note, however, that ^sqlite3_config() can be called as part of the
 ** implementation of an application-defined [sqlite3_os_init()].
 **
@@ -1695,7 +1696,7 @@ SQLITE_API int sqlite3_config(int, ...);
 ** ^Calls to sqlite3_db_config() return SQLITE_OK if and only if
 ** the call is considered successful.
 */
-SQLITE_API int sqlite3_db_config(sqlite3 *, int op, ...);
+SQLITE_API int sqlite3_db_config(sqlite3*, int op, ...);
 
 /*
 ** CAPI3REF: Memory Allocation Routines
@@ -1762,14 +1763,14 @@ SQLITE_API int sqlite3_db_config(sqlite3 *, int op, ...);
 */
 typedef struct sqlite3_mem_methods sqlite3_mem_methods;
 struct sqlite3_mem_methods {
-  void *(*xMalloc)(int);          /* Memory allocation function */
-  void (*xFree)(void *);          /* Free a prior allocation */
-  void *(*xRealloc)(void *, int); /* Resize an allocation */
-  int (*xSize)(void *);           /* Return the size of an allocation */
-  int (*xRoundup)(int);           /* Round up request size to allocation size */
-  int (*xInit)(void *);           /* Initialize the memory allocator */
-  void (*xShutdown)(void *);      /* Deinitialize the memory allocator */
-  void *pAppData;                 /* Argument to xInit() and xShutdown() */
+  void *(*xMalloc)(int);         /* Memory allocation function */
+  void (*xFree)(void*);          /* Free a prior allocation */
+  void *(*xRealloc)(void*,int);  /* Resize an allocation */
+  int (*xSize)(void*);           /* Return the size of an allocation */
+  int (*xRoundup)(int);          /* Round up request size to allocation size */
+  int (*xInit)(void*);           /* Initialize the memory allocator */
+  void (*xShutdown)(void*);      /* Deinitialize the memory allocator */
+  void *pAppData;                /* Argument to xInit() and xShutdown() */
 };
 
 /*
@@ -2142,35 +2143,35 @@ struct sqlite3_mem_methods {
 ** compile-time option is not set, then the default maximum is 1073741824.
 ** </dl>
 */
-#define SQLITE_CONFIG_SINGLETHREAD 1 /* nil */
-#define SQLITE_CONFIG_MULTITHREAD 2  /* nil */
-#define SQLITE_CONFIG_SERIALIZED 3   /* nil */
-#define SQLITE_CONFIG_MALLOC 4       /* sqlite3_mem_methods* */
-#define SQLITE_CONFIG_GETMALLOC 5    /* sqlite3_mem_methods* */
-#define SQLITE_CONFIG_SCRATCH 6      /* No longer used */
-#define SQLITE_CONFIG_PAGECACHE 7    /* void*, int sz, int N */
-#define SQLITE_CONFIG_HEAP 8         /* void*, int nByte, int min */
-#define SQLITE_CONFIG_MEMSTATUS 9    /* boolean */
-#define SQLITE_CONFIG_MUTEX 10       /* sqlite3_mutex_methods* */
-#define SQLITE_CONFIG_GETMUTEX 11    /* sqlite3_mutex_methods* */
+#define SQLITE_CONFIG_SINGLETHREAD         1  /* nil */
+#define SQLITE_CONFIG_MULTITHREAD          2  /* nil */
+#define SQLITE_CONFIG_SERIALIZED           3  /* nil */
+#define SQLITE_CONFIG_MALLOC               4  /* sqlite3_mem_methods* */
+#define SQLITE_CONFIG_GETMALLOC            5  /* sqlite3_mem_methods* */
+#define SQLITE_CONFIG_SCRATCH              6  /* No longer used */
+#define SQLITE_CONFIG_PAGECACHE            7  /* void*, int sz, int N */
+#define SQLITE_CONFIG_HEAP                 8  /* void*, int nByte, int min */
+#define SQLITE_CONFIG_MEMSTATUS            9  /* boolean */
+#define SQLITE_CONFIG_MUTEX               10  /* sqlite3_mutex_methods* */
+#define SQLITE_CONFIG_GETMUTEX            11  /* sqlite3_mutex_methods* */
 /* previously SQLITE_CONFIG_CHUNKALLOC    12 which is now unused. */
-#define SQLITE_CONFIG_LOOKASIDE 13           /* int int */
-#define SQLITE_CONFIG_PCACHE 14              /* no-op */
-#define SQLITE_CONFIG_GETPCACHE 15           /* no-op */
-#define SQLITE_CONFIG_LOG 16                 /* xFunc, void* */
-#define SQLITE_CONFIG_URI 17                 /* int */
-#define SQLITE_CONFIG_PCACHE2 18             /* sqlite3_pcache_methods2* */
-#define SQLITE_CONFIG_GETPCACHE2 19          /* sqlite3_pcache_methods2* */
-#define SQLITE_CONFIG_COVERING_INDEX_SCAN 20 /* int */
-#define SQLITE_CONFIG_SQLLOG 21              /* xSqllog, void* */
-#define SQLITE_CONFIG_MMAP_SIZE 22           /* sqlite3_int64, sqlite3_int64 */
-#define SQLITE_CONFIG_WIN32_HEAPSIZE 23      /* int nByte */
-#define SQLITE_CONFIG_PCACHE_HDRSZ 24        /* int *psz */
-#define SQLITE_CONFIG_PMASZ 25               /* unsigned int szPma */
-#define SQLITE_CONFIG_STMTJRNL_SPILL 26      /* int nByte */
-#define SQLITE_CONFIG_SMALL_MALLOC 27        /* boolean */
-#define SQLITE_CONFIG_SORTERREF_SIZE 28      /* int nByte */
-#define SQLITE_CONFIG_MEMDB_MAXSIZE 29       /* sqlite3_int64 */
+#define SQLITE_CONFIG_LOOKASIDE           13  /* int int */
+#define SQLITE_CONFIG_PCACHE              14  /* no-op */
+#define SQLITE_CONFIG_GETPCACHE           15  /* no-op */
+#define SQLITE_CONFIG_LOG                 16  /* xFunc, void* */
+#define SQLITE_CONFIG_URI                 17  /* int */
+#define SQLITE_CONFIG_PCACHE2             18  /* sqlite3_pcache_methods2* */
+#define SQLITE_CONFIG_GETPCACHE2          19  /* sqlite3_pcache_methods2* */
+#define SQLITE_CONFIG_COVERING_INDEX_SCAN 20  /* int */
+#define SQLITE_CONFIG_SQLLOG              21  /* xSqllog, void* */
+#define SQLITE_CONFIG_MMAP_SIZE           22  /* sqlite3_int64, sqlite3_int64 */
+#define SQLITE_CONFIG_WIN32_HEAPSIZE      23  /* int nByte */
+#define SQLITE_CONFIG_PCACHE_HDRSZ        24  /* int *psz */
+#define SQLITE_CONFIG_PMASZ               25  /* unsigned int szPma */
+#define SQLITE_CONFIG_STMTJRNL_SPILL      26  /* int nByte */
+#define SQLITE_CONFIG_SMALL_MALLOC        27  /* boolean */
+#define SQLITE_CONFIG_SORTERREF_SIZE      28  /* int nByte */
+#define SQLITE_CONFIG_MEMDB_MAXSIZE       29  /* sqlite3_int64 */
 
 /*
 ** CAPI3REF: Database Connection Configuration Options
@@ -2490,27 +2491,27 @@ struct sqlite3_mem_methods {
 **
 ** </dl>
 */
-#define SQLITE_DBCONFIG_MAINDBNAME 1000            /* const char* */
-#define SQLITE_DBCONFIG_LOOKASIDE 1001             /* void* int int */
-#define SQLITE_DBCONFIG_ENABLE_FKEY 1002           /* int int* */
-#define SQLITE_DBCONFIG_ENABLE_TRIGGER 1003        /* int int* */
+#define SQLITE_DBCONFIG_MAINDBNAME            1000 /* const char* */
+#define SQLITE_DBCONFIG_LOOKASIDE             1001 /* void* int int */
+#define SQLITE_DBCONFIG_ENABLE_FKEY           1002 /* int int* */
+#define SQLITE_DBCONFIG_ENABLE_TRIGGER        1003 /* int int* */
 #define SQLITE_DBCONFIG_ENABLE_FTS3_TOKENIZER 1004 /* int int* */
 #define SQLITE_DBCONFIG_ENABLE_LOAD_EXTENSION 1005 /* int int* */
-#define SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE 1006      /* int int* */
-#define SQLITE_DBCONFIG_ENABLE_QPSG 1007           /* int int* */
-#define SQLITE_DBCONFIG_TRIGGER_EQP 1008           /* int int* */
-#define SQLITE_DBCONFIG_RESET_DATABASE 1009        /* int int* */
-#define SQLITE_DBCONFIG_DEFENSIVE 1010             /* int int* */
-#define SQLITE_DBCONFIG_WRITABLE_SCHEMA 1011       /* int int* */
-#define SQLITE_DBCONFIG_LEGACY_ALTER_TABLE 1012    /* int int* */
-#define SQLITE_DBCONFIG_DQS_DML 1013               /* int int* */
-#define SQLITE_DBCONFIG_DQS_DDL 1014               /* int int* */
-#define SQLITE_DBCONFIG_ENABLE_VIEW 1015           /* int int* */
-#define SQLITE_DBCONFIG_LEGACY_FILE_FORMAT 1016    /* int int* */
-#define SQLITE_DBCONFIG_TRUSTED_SCHEMA 1017        /* int int* */
-#define SQLITE_DBCONFIG_STMT_SCANSTATUS 1018       /* int int* */
-#define SQLITE_DBCONFIG_REVERSE_SCANORDER 1019     /* int int* */
-#define SQLITE_DBCONFIG_MAX 1019                   /* Largest DBCONFIG */
+#define SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE      1006 /* int int* */
+#define SQLITE_DBCONFIG_ENABLE_QPSG           1007 /* int int* */
+#define SQLITE_DBCONFIG_TRIGGER_EQP           1008 /* int int* */
+#define SQLITE_DBCONFIG_RESET_DATABASE        1009 /* int int* */
+#define SQLITE_DBCONFIG_DEFENSIVE             1010 /* int int* */
+#define SQLITE_DBCONFIG_WRITABLE_SCHEMA       1011 /* int int* */
+#define SQLITE_DBCONFIG_LEGACY_ALTER_TABLE    1012 /* int int* */
+#define SQLITE_DBCONFIG_DQS_DML               1013 /* int int* */
+#define SQLITE_DBCONFIG_DQS_DDL               1014 /* int int* */
+#define SQLITE_DBCONFIG_ENABLE_VIEW           1015 /* int int* */
+#define SQLITE_DBCONFIG_LEGACY_FILE_FORMAT    1016 /* int int* */
+#define SQLITE_DBCONFIG_TRUSTED_SCHEMA        1017 /* int int* */
+#define SQLITE_DBCONFIG_STMT_SCANSTATUS       1018 /* int int* */
+#define SQLITE_DBCONFIG_REVERSE_SCANORDER     1019 /* int int* */
+#define SQLITE_DBCONFIG_MAX                   1019 /* Largest DBCONFIG */
 
 /*
 ** CAPI3REF: Enable Or Disable Extended Result Codes
@@ -2520,7 +2521,7 @@ struct sqlite3_mem_methods {
 ** [extended result codes] feature of SQLite. ^The extended result
 ** codes are disabled by default for historical compatibility.
 */
-SQLITE_API int sqlite3_extended_result_codes(sqlite3 *, int onoff);
+SQLITE_API int sqlite3_extended_result_codes(sqlite3*, int onoff);
 
 /*
 ** CAPI3REF: Last Insert Rowid
@@ -2582,7 +2583,7 @@ SQLITE_API int sqlite3_extended_result_codes(sqlite3 *, int onoff);
 ** unpredictable and might not equal either the old or the new
 ** last insert [rowid].
 */
-SQLITE_API sqlite3_int64 sqlite3_last_insert_rowid(sqlite3 *);
+SQLITE_API sqlite3_int64 sqlite3_last_insert_rowid(sqlite3*);
 
 /*
 ** CAPI3REF: Set the Last Insert Rowid value.
@@ -2592,7 +2593,7 @@ SQLITE_API sqlite3_int64 sqlite3_last_insert_rowid(sqlite3 *);
 ** set the value returned by calling sqlite3_last_insert_rowid(D) to R
 ** without inserting a row into the database.
 */
-SQLITE_API void sqlite3_set_last_insert_rowid(sqlite3 *, sqlite3_int64);
+SQLITE_API void sqlite3_set_last_insert_rowid(sqlite3*,sqlite3_int64);
 
 /*
 ** CAPI3REF: Count The Number Of Rows Modified
@@ -2653,8 +2654,8 @@ SQLITE_API void sqlite3_set_last_insert_rowid(sqlite3 *, sqlite3_int64);
 ** <li> the [data_version pragma]
 ** </ul>
 */
-SQLITE_API int sqlite3_changes(sqlite3 *);
-SQLITE_API sqlite3_int64 sqlite3_changes64(sqlite3 *);
+SQLITE_API int sqlite3_changes(sqlite3*);
+SQLITE_API sqlite3_int64 sqlite3_changes64(sqlite3*);
 
 /*
 ** CAPI3REF: Total Number Of Rows Modified
@@ -2695,8 +2696,8 @@ SQLITE_API sqlite3_int64 sqlite3_changes64(sqlite3 *);
 ** <li> the [SQLITE_FCNTL_DATA_VERSION] [file control]
 ** </ul>
 */
-SQLITE_API int sqlite3_total_changes(sqlite3 *);
-SQLITE_API sqlite3_int64 sqlite3_total_changes64(sqlite3 *);
+SQLITE_API int sqlite3_total_changes(sqlite3*);
+SQLITE_API sqlite3_int64 sqlite3_total_changes64(sqlite3*);
 
 /*
 ** CAPI3REF: Interrupt A Long-Running Query
@@ -2737,8 +2738,8 @@ SQLITE_API sqlite3_int64 sqlite3_total_changes64(sqlite3 *);
 ** or not an interrupt is currently in effect for [database connection] D.
 ** It returns 1 if an interrupt is currently in effect, or 0 otherwise.
 */
-SQLITE_API void sqlite3_interrupt(sqlite3 *);
-SQLITE_API int sqlite3_is_interrupted(sqlite3 *);
+SQLITE_API void sqlite3_interrupt(sqlite3*);
+SQLITE_API int sqlite3_is_interrupted(sqlite3*);
 
 /*
 ** CAPI3REF: Determine If An SQL Statement Is Complete
@@ -2835,7 +2836,7 @@ SQLITE_API int sqlite3_complete16(const void *sql);
 ** A busy handler must not close the database connection
 ** or [prepared statement] that invoked the busy handler.
 */
-SQLITE_API int sqlite3_busy_handler(sqlite3 *, int (*)(void *, int), void *);
+SQLITE_API int sqlite3_busy_handler(sqlite3*,int(*)(void*,int),void*);
 
 /*
 ** CAPI3REF: Set A Busy Timeout
@@ -2858,7 +2859,7 @@ SQLITE_API int sqlite3_busy_handler(sqlite3 *, int (*)(void *, int), void *);
 **
 ** See also:  [PRAGMA busy_timeout]
 */
-SQLITE_API int sqlite3_busy_timeout(sqlite3 *, int ms);
+SQLITE_API int sqlite3_busy_timeout(sqlite3*, int ms);
 
 /*
 ** CAPI3REF: Convenience Routines For Running Queries
@@ -2933,13 +2934,13 @@ SQLITE_API int sqlite3_busy_timeout(sqlite3 *, int ms);
 ** reflected in subsequent calls to [sqlite3_errcode()] or
 ** [sqlite3_errmsg()].
 */
-SQLITE_API int
-sqlite3_get_table(sqlite3 *db,       /* An open database */
-                  const char *zSql,  /* SQL to be evaluated */
-                  char ***pazResult, /* Results of the query */
-                  int *pnRow,        /* Number of result rows written here */
-                  int *pnColumn,     /* Number of result columns written here */
-                  char **pzErrmsg    /* Error msg written here */
+SQLITE_API int sqlite3_get_table(
+  sqlite3 *db,          /* An open database */
+  const char *zSql,     /* SQL to be evaluated */
+  char ***pazResult,    /* Results of the query */
+  int *pnRow,           /* Number of result rows written here */
+  int *pnColumn,        /* Number of result columns written here */
+  char **pzErrmsg       /* Error msg written here */
 );
 SQLITE_API void sqlite3_free_table(char **result);
 
@@ -2983,10 +2984,10 @@ SQLITE_API void sqlite3_free_table(char **result);
 **
 ** See also:  [built-in printf()], [printf() SQL function]
 */
-SQLITE_API char *sqlite3_mprintf(const char *, ...);
-SQLITE_API char *sqlite3_vmprintf(const char *, va_list);
-SQLITE_API char *sqlite3_snprintf(int, char *, const char *, ...);
-SQLITE_API char *sqlite3_vsnprintf(int, char *, const char *, va_list);
+SQLITE_API char *sqlite3_mprintf(const char*,...);
+SQLITE_API char *sqlite3_vmprintf(const char*, va_list);
+SQLITE_API char *sqlite3_snprintf(int,char*,const char*, ...);
+SQLITE_API char *sqlite3_vsnprintf(int,char*,const char*, va_list);
 
 /*
 ** CAPI3REF: Memory Allocation Subsystem
@@ -3065,10 +3066,10 @@ SQLITE_API char *sqlite3_vsnprintf(int, char *, const char *, va_list);
 */
 SQLITE_API void *sqlite3_malloc(int);
 SQLITE_API void *sqlite3_malloc64(sqlite3_uint64);
-SQLITE_API void *sqlite3_realloc(void *, int);
-SQLITE_API void *sqlite3_realloc64(void *, sqlite3_uint64);
-SQLITE_API void sqlite3_free(void *);
-SQLITE_API sqlite3_uint64 sqlite3_msize(void *);
+SQLITE_API void *sqlite3_realloc(void*, int);
+SQLITE_API void *sqlite3_realloc64(void*, sqlite3_uint64);
+SQLITE_API void sqlite3_free(void*);
+SQLITE_API sqlite3_uint64 sqlite3_msize(void*);
 
 /*
 ** CAPI3REF: Memory Allocator Statistics
@@ -3208,11 +3209,11 @@ SQLITE_API void sqlite3_randomness(int N, void *P);
 ** as stated in the previous paragraph, sqlite3_step() invokes
 ** sqlite3_prepare_v2() to reprepare a statement after a schema change.
 */
-SQLITE_API int sqlite3_set_authorizer(sqlite3 *,
-                                      int (*xAuth)(void *, int, const char *,
-                                                   const char *, const char *,
-                                                   const char *),
-                                      void *pUserData);
+SQLITE_API int sqlite3_set_authorizer(
+  sqlite3*,
+  int (*xAuth)(void*,int,const char*,const char*,const char*,const char*),
+  void *pUserData
+);
 
 /*
 ** CAPI3REF: Authorizer Return Codes
@@ -3226,8 +3227,8 @@ SQLITE_API int sqlite3_set_authorizer(sqlite3 *,
 ** Note that SQLITE_IGNORE is also used as a [conflict resolution mode]
 ** returned from the [sqlite3_vtab_on_conflict()] interface.
 */
-#define SQLITE_DENY 1   /* Abort the SQL statement with an error */
-#define SQLITE_IGNORE 2 /* Don't allow access, but don't generate an error */
+#define SQLITE_DENY   1   /* Abort the SQL statement with an error */
+#define SQLITE_IGNORE 2   /* Don't allow access, but don't generate an error */
 
 /*
 ** CAPI3REF: Authorizer Action Codes
@@ -3249,40 +3250,40 @@ SQLITE_API int sqlite3_set_authorizer(sqlite3 *,
 ** top-level SQL code.
 */
 /******************************************* 3rd ************ 4th ***********/
-#define SQLITE_CREATE_INDEX 1        /* Index Name      Table Name      */
-#define SQLITE_CREATE_TABLE 2        /* Table Name      NULL            */
-#define SQLITE_CREATE_TEMP_INDEX 3   /* Index Name      Table Name      */
-#define SQLITE_CREATE_TEMP_TABLE 4   /* Table Name      NULL            */
-#define SQLITE_CREATE_TEMP_TRIGGER 5 /* Trigger Name    Table Name      */
-#define SQLITE_CREATE_TEMP_VIEW 6    /* View Name       NULL            */
-#define SQLITE_CREATE_TRIGGER 7      /* Trigger Name    Table Name      */
-#define SQLITE_CREATE_VIEW 8         /* View Name       NULL            */
-#define SQLITE_DELETE 9              /* Table Name      NULL            */
-#define SQLITE_DROP_INDEX 10         /* Index Name      Table Name      */
-#define SQLITE_DROP_TABLE 11         /* Table Name      NULL            */
-#define SQLITE_DROP_TEMP_INDEX 12    /* Index Name      Table Name      */
-#define SQLITE_DROP_TEMP_TABLE 13    /* Table Name      NULL            */
-#define SQLITE_DROP_TEMP_TRIGGER 14  /* Trigger Name    Table Name      */
-#define SQLITE_DROP_TEMP_VIEW 15     /* View Name       NULL            */
-#define SQLITE_DROP_TRIGGER 16       /* Trigger Name    Table Name      */
-#define SQLITE_DROP_VIEW 17          /* View Name       NULL            */
-#define SQLITE_INSERT 18             /* Table Name      NULL            */
-#define SQLITE_PRAGMA 19             /* Pragma Name     1st arg or NULL */
-#define SQLITE_READ 20               /* Table Name      Column Name     */
-#define SQLITE_SELECT 21             /* NULL            NULL            */
-#define SQLITE_TRANSACTION 22        /* Operation       NULL            */
-#define SQLITE_UPDATE 23             /* Table Name      Column Name     */
-#define SQLITE_ATTACH 24             /* Filename        NULL            */
-#define SQLITE_DETACH 25             /* Database Name   NULL            */
-#define SQLITE_ALTER_TABLE 26        /* Database Name   Table Name      */
-#define SQLITE_REINDEX 27            /* Index Name      NULL            */
-#define SQLITE_ANALYZE 28            /* Table Name      NULL            */
-#define SQLITE_CREATE_VTABLE 29      /* Table Name      Module Name     */
-#define SQLITE_DROP_VTABLE 30        /* Table Name      Module Name     */
-#define SQLITE_FUNCTION 31           /* NULL            Function Name   */
-#define SQLITE_SAVEPOINT 32          /* Operation       Savepoint Name  */
-#define SQLITE_COPY 0                /* No longer used */
-#define SQLITE_RECURSIVE 33          /* NULL            NULL            */
+#define SQLITE_CREATE_INDEX          1   /* Index Name      Table Name      */
+#define SQLITE_CREATE_TABLE          2   /* Table Name      NULL            */
+#define SQLITE_CREATE_TEMP_INDEX     3   /* Index Name      Table Name      */
+#define SQLITE_CREATE_TEMP_TABLE     4   /* Table Name      NULL            */
+#define SQLITE_CREATE_TEMP_TRIGGER   5   /* Trigger Name    Table Name      */
+#define SQLITE_CREATE_TEMP_VIEW      6   /* View Name       NULL            */
+#define SQLITE_CREATE_TRIGGER        7   /* Trigger Name    Table Name      */
+#define SQLITE_CREATE_VIEW           8   /* View Name       NULL            */
+#define SQLITE_DELETE                9   /* Table Name      NULL            */
+#define SQLITE_DROP_INDEX           10   /* Index Name      Table Name      */
+#define SQLITE_DROP_TABLE           11   /* Table Name      NULL            */
+#define SQLITE_DROP_TEMP_INDEX      12   /* Index Name      Table Name      */
+#define SQLITE_DROP_TEMP_TABLE      13   /* Table Name      NULL            */
+#define SQLITE_DROP_TEMP_TRIGGER    14   /* Trigger Name    Table Name      */
+#define SQLITE_DROP_TEMP_VIEW       15   /* View Name       NULL            */
+#define SQLITE_DROP_TRIGGER         16   /* Trigger Name    Table Name      */
+#define SQLITE_DROP_VIEW            17   /* View Name       NULL            */
+#define SQLITE_INSERT               18   /* Table Name      NULL            */
+#define SQLITE_PRAGMA               19   /* Pragma Name     1st arg or NULL */
+#define SQLITE_READ                 20   /* Table Name      Column Name     */
+#define SQLITE_SELECT               21   /* NULL            NULL            */
+#define SQLITE_TRANSACTION          22   /* Operation       NULL            */
+#define SQLITE_UPDATE               23   /* Table Name      Column Name     */
+#define SQLITE_ATTACH               24   /* Filename        NULL            */
+#define SQLITE_DETACH               25   /* Database Name   NULL            */
+#define SQLITE_ALTER_TABLE          26   /* Database Name   Table Name      */
+#define SQLITE_REINDEX              27   /* Index Name      NULL            */
+#define SQLITE_ANALYZE              28   /* Table Name      NULL            */
+#define SQLITE_CREATE_VTABLE        29   /* Table Name      Module Name     */
+#define SQLITE_DROP_VTABLE          30   /* Table Name      Module Name     */
+#define SQLITE_FUNCTION             31   /* NULL            Function Name   */
+#define SQLITE_SAVEPOINT            32   /* Operation       Savepoint Name  */
+#define SQLITE_COPY                  0   /* No longer used */
+#define SQLITE_RECURSIVE            33   /* NULL            NULL            */
 
 /*
 ** CAPI3REF: Tracing And Profiling Functions
@@ -3316,11 +3317,10 @@ SQLITE_API int sqlite3_set_authorizer(sqlite3 *,
 ** either [sqlite3_trace()] or [sqlite3_trace_v2()] will cancel the
 ** profile callback.
 */
-SQLITE_API SQLITE_DEPRECATED void *
-sqlite3_trace(sqlite3 *, void (*xTrace)(void *, const char *), void *);
-SQLITE_API SQLITE_DEPRECATED void *
-sqlite3_profile(sqlite3 *,
-                void (*xProfile)(void *, const char *, sqlite3_uint64), void *);
+SQLITE_API SQLITE_DEPRECATED void *sqlite3_trace(sqlite3*,
+   void(*xTrace)(void*,const char*), void*);
+SQLITE_API SQLITE_DEPRECATED void *sqlite3_profile(sqlite3*,
+   void(*xProfile)(void*,const char*,sqlite3_uint64), void*);
 
 /*
 ** CAPI3REF: SQL Trace Event Codes
@@ -3374,10 +3374,10 @@ sqlite3_profile(sqlite3 *,
 ** and the X argument is unused.
 ** </dl>
 */
-#define SQLITE_TRACE_STMT 0x01
-#define SQLITE_TRACE_PROFILE 0x02
-#define SQLITE_TRACE_ROW 0x04
-#define SQLITE_TRACE_CLOSE 0x08
+#define SQLITE_TRACE_STMT       0x01
+#define SQLITE_TRACE_PROFILE    0x02
+#define SQLITE_TRACE_ROW        0x04
+#define SQLITE_TRACE_CLOSE      0x08
 
 /*
 ** CAPI3REF: SQL Trace Hook
@@ -3410,10 +3410,12 @@ sqlite3_profile(sqlite3 *,
 ** interfaces [sqlite3_trace()] and [sqlite3_profile()], both of which
 ** are deprecated.
 */
-SQLITE_API int sqlite3_trace_v2(sqlite3 *, unsigned uMask,
-                                int (*xCallback)(unsigned, void *, void *,
-                                                 void *),
-                                void *pCtx);
+SQLITE_API int sqlite3_trace_v2(
+  sqlite3*,
+  unsigned uMask,
+  int(*xCallback)(unsigned,void*,void*,void*),
+  void *pCtx
+);
 
 /*
 ** CAPI3REF: Query Progress Callbacks
@@ -3454,8 +3456,7 @@ SQLITE_API int sqlite3_trace_v2(sqlite3 *, unsigned uMask,
 ** invoked directly from [sqlite3_prepare()] while analyzing and generating
 ** code for complex queries.
 */
-SQLITE_API void sqlite3_progress_handler(sqlite3 *, int, int (*)(void *),
-                                         void *);
+SQLITE_API void sqlite3_progress_handler(sqlite3*, int, int(*)(void*), void*);
 
 /*
 ** CAPI3REF: Opening A New Database Connection
@@ -3735,19 +3736,19 @@ SQLITE_API void sqlite3_progress_handler(sqlite3 *, int, int (*)(void *),
 **
 ** See also: [sqlite3_temp_directory]
 */
-SQLITE_API int
-sqlite3_open(const char *filename, /* Database filename (UTF-8) */
-             sqlite3 **ppDb        /* OUT: SQLite db handle */
+SQLITE_API int sqlite3_open(
+  const char *filename,   /* Database filename (UTF-8) */
+  sqlite3 **ppDb          /* OUT: SQLite db handle */
 );
-SQLITE_API int
-sqlite3_open16(const void *filename, /* Database filename (UTF-16) */
-               sqlite3 **ppDb        /* OUT: SQLite db handle */
+SQLITE_API int sqlite3_open16(
+  const void *filename,   /* Database filename (UTF-16) */
+  sqlite3 **ppDb          /* OUT: SQLite db handle */
 );
-SQLITE_API int
-sqlite3_open_v2(const char *filename, /* Database filename (UTF-8) */
-                sqlite3 **ppDb,       /* OUT: SQLite db handle */
-                int flags,            /* Flags */
-                const char *zVfs      /* Name of VFS module to use */
+SQLITE_API int sqlite3_open_v2(
+  const char *filename,   /* Database filename (UTF-8) */
+  sqlite3 **ppDb,         /* OUT: SQLite db handle */
+  int flags,              /* Flags */
+  const char *zVfs        /* Name of VFS module to use */
 );
 
 /*
@@ -3816,12 +3817,9 @@ sqlite3_open_v2(const char *filename, /* Database filename (UTF-8) */
 **
 ** See the [URI filename] documentation for additional information.
 */
-SQLITE_API const char *sqlite3_uri_parameter(sqlite3_filename z,
-                                             const char *zParam);
-SQLITE_API int sqlite3_uri_boolean(sqlite3_filename z, const char *zParam,
-                                   int bDefault);
-SQLITE_API sqlite3_int64 sqlite3_uri_int64(sqlite3_filename, const char *,
-                                           sqlite3_int64);
+SQLITE_API const char *sqlite3_uri_parameter(sqlite3_filename z, const char *zParam);
+SQLITE_API int sqlite3_uri_boolean(sqlite3_filename z, const char *zParam, int bDefault);
+SQLITE_API sqlite3_int64 sqlite3_uri_int64(sqlite3_filename, const char*, sqlite3_int64);
 SQLITE_API const char *sqlite3_uri_key(sqlite3_filename z, int N);
 
 /*
@@ -3872,7 +3870,7 @@ SQLITE_API const char *sqlite3_filename_wal(sqlite3_filename);
 ** of this routine results in undefined and probably undesirable
 ** behavior.
 */
-SQLITE_API sqlite3_file *sqlite3_database_file_object(const char *);
+SQLITE_API sqlite3_file *sqlite3_database_file_object(const char*);
 
 /*
 ** CAPI3REF: Create and Destroy VFS Filenames
@@ -3919,11 +3917,13 @@ SQLITE_API sqlite3_file *sqlite3_database_file_object(const char *);
 ** then the corresponding [sqlite3_module.xClose() method should also be
 ** invoked prior to calling sqlite3_free_filename(Y).
 */
-SQLITE_API sqlite3_filename sqlite3_create_filename(const char *zDatabase,
-                                                    const char *zJournal,
-                                                    const char *zWal,
-                                                    int nParam,
-                                                    const char **azParam);
+SQLITE_API sqlite3_filename sqlite3_create_filename(
+  const char *zDatabase,
+  const char *zJournal,
+  const char *zWal,
+  int nParam,
+  const char **azParam
+);
 SQLITE_API void sqlite3_free_filename(sqlite3_filename);
 
 /*
@@ -3954,15 +3954,17 @@ SQLITE_API void sqlite3_free_filename(sqlite3_filename);
 ** </ul>
 **
 ** ^The sqlite3_errmsg() and sqlite3_errmsg16() return English-language
-** text that describes the error, as either UTF-8 or UTF-16 respectively.
+** text that describes the error, as either UTF-8 or UTF-16 respectively,
+** or NULL if no error message is available.
 ** (See how SQLite handles [invalid UTF] for exceptions to this rule.)
 ** ^(Memory to hold the error message string is managed internally.
 ** The application does not need to worry about freeing the result.
 ** However, the error string might be overwritten or deallocated by
 ** subsequent calls to other SQLite interface functions.)^
 **
-** ^The sqlite3_errstr() interface returns the English-language text
-** that describes the [result code], as UTF-8.
+** ^The sqlite3_errstr(E) interface returns the English-language text
+** that describes the [result code] E, as UTF-8, or NULL if E is not an
+** result code for which a text error message is available.
 ** ^(Memory to hold the error message string is managed internally
 ** and must not be freed by the application)^.
 **
@@ -3989,8 +3991,8 @@ SQLITE_API void sqlite3_free_filename(sqlite3_filename);
 */
 SQLITE_API int sqlite3_errcode(sqlite3 *db);
 SQLITE_API int sqlite3_extended_errcode(sqlite3 *db);
-SQLITE_API const char *sqlite3_errmsg(sqlite3 *);
-SQLITE_API const void *sqlite3_errmsg16(sqlite3 *);
+SQLITE_API const char *sqlite3_errmsg(sqlite3*);
+SQLITE_API const void *sqlite3_errmsg16(sqlite3*);
 SQLITE_API const char *sqlite3_errstr(int);
 SQLITE_API int sqlite3_error_offset(sqlite3 *db);
 
@@ -4060,7 +4062,7 @@ typedef struct sqlite3_stmt sqlite3_stmt;
 **
 ** New run-time limit categories may be added in future releases.
 */
-SQLITE_API int sqlite3_limit(sqlite3 *, int id, int newVal);
+SQLITE_API int sqlite3_limit(sqlite3*, int id, int newVal);
 
 /*
 ** CAPI3REF: Run-Time Limit Categories
@@ -4118,18 +4120,18 @@ SQLITE_API int sqlite3_limit(sqlite3 *, int id, int newVal);
 ** [prepared statement] may start.</dd>)^
 ** </dl>
 */
-#define SQLITE_LIMIT_LENGTH 0
-#define SQLITE_LIMIT_SQL_LENGTH 1
-#define SQLITE_LIMIT_COLUMN 2
-#define SQLITE_LIMIT_EXPR_DEPTH 3
-#define SQLITE_LIMIT_COMPOUND_SELECT 4
-#define SQLITE_LIMIT_VDBE_OP 5
-#define SQLITE_LIMIT_FUNCTION_ARG 6
-#define SQLITE_LIMIT_ATTACHED 7
-#define SQLITE_LIMIT_LIKE_PATTERN_LENGTH 8
-#define SQLITE_LIMIT_VARIABLE_NUMBER 9
-#define SQLITE_LIMIT_TRIGGER_DEPTH 10
-#define SQLITE_LIMIT_WORKER_THREADS 11
+#define SQLITE_LIMIT_LENGTH                    0
+#define SQLITE_LIMIT_SQL_LENGTH                1
+#define SQLITE_LIMIT_COLUMN                    2
+#define SQLITE_LIMIT_EXPR_DEPTH                3
+#define SQLITE_LIMIT_COMPOUND_SELECT           4
+#define SQLITE_LIMIT_VDBE_OP                   5
+#define SQLITE_LIMIT_FUNCTION_ARG              6
+#define SQLITE_LIMIT_ATTACHED                  7
+#define SQLITE_LIMIT_LIKE_PATTERN_LENGTH       8
+#define SQLITE_LIMIT_VARIABLE_NUMBER           9
+#define SQLITE_LIMIT_TRIGGER_DEPTH            10
+#define SQLITE_LIMIT_WORKER_THREADS           11
 
 /*
 ** CAPI3REF: Prepare Flags
@@ -4166,9 +4168,9 @@ SQLITE_API int sqlite3_limit(sqlite3 *, int id, int newVal);
 ** any virtual tables.
 ** </dl>
 */
-#define SQLITE_PREPARE_PERSISTENT 0x01
-#define SQLITE_PREPARE_NORMALIZE 0x02
-#define SQLITE_PREPARE_NO_VTAB 0x04
+#define SQLITE_PREPARE_PERSISTENT              0x01
+#define SQLITE_PREPARE_NORMALIZE               0x02
+#define SQLITE_PREPARE_NO_VTAB                 0x04
 
 /*
 ** CAPI3REF: Compiling An SQL Statement
@@ -4270,49 +4272,49 @@ SQLITE_API int sqlite3_limit(sqlite3 *, int id, int newVal);
 ** sqlite3_prepare_v2() interface works exactly the same as
 ** sqlite3_prepare_v3() with a zero prepFlags parameter.
 */
-SQLITE_API int
-sqlite3_prepare(sqlite3 *db,           /* Database handle */
-                const char *zSql,      /* SQL statement, UTF-8 encoded */
-                int nByte,             /* Maximum length of zSql in bytes. */
-                sqlite3_stmt **ppStmt, /* OUT: Statement handle */
-                const char **pzTail /* OUT: Pointer to unused portion of zSql */
+SQLITE_API int sqlite3_prepare(
+  sqlite3 *db,            /* Database handle */
+  const char *zSql,       /* SQL statement, UTF-8 encoded */
+  int nByte,              /* Maximum length of zSql in bytes. */
+  sqlite3_stmt **ppStmt,  /* OUT: Statement handle */
+  const char **pzTail     /* OUT: Pointer to unused portion of zSql */
 );
 SQLITE_API int sqlite3_prepare_v2(
-    sqlite3 *db,           /* Database handle */
-    const char *zSql,      /* SQL statement, UTF-8 encoded */
-    int nByte,             /* Maximum length of zSql in bytes. */
-    sqlite3_stmt **ppStmt, /* OUT: Statement handle */
-    const char **pzTail    /* OUT: Pointer to unused portion of zSql */
+  sqlite3 *db,            /* Database handle */
+  const char *zSql,       /* SQL statement, UTF-8 encoded */
+  int nByte,              /* Maximum length of zSql in bytes. */
+  sqlite3_stmt **ppStmt,  /* OUT: Statement handle */
+  const char **pzTail     /* OUT: Pointer to unused portion of zSql */
 );
 SQLITE_API int sqlite3_prepare_v3(
-    sqlite3 *db,            /* Database handle */
-    const char *zSql,       /* SQL statement, UTF-8 encoded */
-    int nByte,              /* Maximum length of zSql in bytes. */
-    unsigned int prepFlags, /* Zero or more SQLITE_PREPARE_ flags */
-    sqlite3_stmt **ppStmt,  /* OUT: Statement handle */
-    const char **pzTail     /* OUT: Pointer to unused portion of zSql */
+  sqlite3 *db,            /* Database handle */
+  const char *zSql,       /* SQL statement, UTF-8 encoded */
+  int nByte,              /* Maximum length of zSql in bytes. */
+  unsigned int prepFlags, /* Zero or more SQLITE_PREPARE_ flags */
+  sqlite3_stmt **ppStmt,  /* OUT: Statement handle */
+  const char **pzTail     /* OUT: Pointer to unused portion of zSql */
 );
 SQLITE_API int sqlite3_prepare16(
-    sqlite3 *db,           /* Database handle */
-    const void *zSql,      /* SQL statement, UTF-16 encoded */
-    int nByte,             /* Maximum length of zSql in bytes. */
-    sqlite3_stmt **ppStmt, /* OUT: Statement handle */
-    const void **pzTail    /* OUT: Pointer to unused portion of zSql */
+  sqlite3 *db,            /* Database handle */
+  const void *zSql,       /* SQL statement, UTF-16 encoded */
+  int nByte,              /* Maximum length of zSql in bytes. */
+  sqlite3_stmt **ppStmt,  /* OUT: Statement handle */
+  const void **pzTail     /* OUT: Pointer to unused portion of zSql */
 );
 SQLITE_API int sqlite3_prepare16_v2(
-    sqlite3 *db,           /* Database handle */
-    const void *zSql,      /* SQL statement, UTF-16 encoded */
-    int nByte,             /* Maximum length of zSql in bytes. */
-    sqlite3_stmt **ppStmt, /* OUT: Statement handle */
-    const void **pzTail    /* OUT: Pointer to unused portion of zSql */
+  sqlite3 *db,            /* Database handle */
+  const void *zSql,       /* SQL statement, UTF-16 encoded */
+  int nByte,              /* Maximum length of zSql in bytes. */
+  sqlite3_stmt **ppStmt,  /* OUT: Statement handle */
+  const void **pzTail     /* OUT: Pointer to unused portion of zSql */
 );
 SQLITE_API int sqlite3_prepare16_v3(
-    sqlite3 *db,            /* Database handle */
-    const void *zSql,       /* SQL statement, UTF-16 encoded */
-    int nByte,              /* Maximum length of zSql in bytes. */
-    unsigned int prepFlags, /* Zero or more SQLITE_PREPARE_ flags */
-    sqlite3_stmt **ppStmt,  /* OUT: Statement handle */
-    const void **pzTail     /* OUT: Pointer to unused portion of zSql */
+  sqlite3 *db,            /* Database handle */
+  const void *zSql,       /* SQL statement, UTF-16 encoded */
+  int nByte,              /* Maximum length of zSql in bytes. */
+  unsigned int prepFlags, /* Zero or more SQLITE_PREPARE_ flags */
+  sqlite3_stmt **ppStmt,  /* OUT: Statement handle */
+  const void **pzTail     /* OUT: Pointer to unused portion of zSql */
 );
 
 /*
@@ -4477,7 +4479,7 @@ SQLITE_API int sqlite3_stmt_explain(sqlite3_stmt *pStmt, int eMode);
 ** for example, in diagnostic routines to search for prepared
 ** statements that are holding a transaction open.
 */
-SQLITE_API int sqlite3_stmt_busy(sqlite3_stmt *);
+SQLITE_API int sqlite3_stmt_busy(sqlite3_stmt*);
 
 /*
 ** CAPI3REF: Dynamically Typed Value Object
@@ -4677,26 +4679,21 @@ typedef struct sqlite3_context sqlite3_context;
 ** See also: [sqlite3_bind_parameter_count()],
 ** [sqlite3_bind_parameter_name()], and [sqlite3_bind_parameter_index()].
 */
-SQLITE_API int sqlite3_bind_blob(sqlite3_stmt *, int, const void *, int n,
-                                 void (*)(void *));
-SQLITE_API int sqlite3_bind_blob64(sqlite3_stmt *, int, const void *,
-                                   sqlite3_uint64, void (*)(void *));
-SQLITE_API int sqlite3_bind_double(sqlite3_stmt *, int, double);
-SQLITE_API int sqlite3_bind_int(sqlite3_stmt *, int, int);
-SQLITE_API int sqlite3_bind_int64(sqlite3_stmt *, int, sqlite3_int64);
-SQLITE_API int sqlite3_bind_null(sqlite3_stmt *, int);
-SQLITE_API int sqlite3_bind_text(sqlite3_stmt *, int, const char *, int,
-                                 void (*)(void *));
-SQLITE_API int sqlite3_bind_text16(sqlite3_stmt *, int, const void *, int,
-                                   void (*)(void *));
-SQLITE_API int sqlite3_bind_text64(sqlite3_stmt *, int, const char *,
-                                   sqlite3_uint64, void (*)(void *),
-                                   unsigned char encoding);
-SQLITE_API int sqlite3_bind_value(sqlite3_stmt *, int, const sqlite3_value *);
-SQLITE_API int sqlite3_bind_pointer(sqlite3_stmt *, int, void *, const char *,
-                                    void (*)(void *));
-SQLITE_API int sqlite3_bind_zeroblob(sqlite3_stmt *, int, int n);
-SQLITE_API int sqlite3_bind_zeroblob64(sqlite3_stmt *, int, sqlite3_uint64);
+SQLITE_API int sqlite3_bind_blob(sqlite3_stmt*, int, const void*, int n, void(*)(void*));
+SQLITE_API int sqlite3_bind_blob64(sqlite3_stmt*, int, const void*, sqlite3_uint64,
+                        void(*)(void*));
+SQLITE_API int sqlite3_bind_double(sqlite3_stmt*, int, double);
+SQLITE_API int sqlite3_bind_int(sqlite3_stmt*, int, int);
+SQLITE_API int sqlite3_bind_int64(sqlite3_stmt*, int, sqlite3_int64);
+SQLITE_API int sqlite3_bind_null(sqlite3_stmt*, int);
+SQLITE_API int sqlite3_bind_text(sqlite3_stmt*,int,const char*,int,void(*)(void*));
+SQLITE_API int sqlite3_bind_text16(sqlite3_stmt*, int, const void*, int, void(*)(void*));
+SQLITE_API int sqlite3_bind_text64(sqlite3_stmt*, int, const char*, sqlite3_uint64,
+                         void(*)(void*), unsigned char encoding);
+SQLITE_API int sqlite3_bind_value(sqlite3_stmt*, int, const sqlite3_value*);
+SQLITE_API int sqlite3_bind_pointer(sqlite3_stmt*, int, void*, const char*,void(*)(void*));
+SQLITE_API int sqlite3_bind_zeroblob(sqlite3_stmt*, int, int n);
+SQLITE_API int sqlite3_bind_zeroblob64(sqlite3_stmt*, int, sqlite3_uint64);
 
 /*
 ** CAPI3REF: Number Of SQL Parameters
@@ -4717,7 +4714,7 @@ SQLITE_API int sqlite3_bind_zeroblob64(sqlite3_stmt *, int, sqlite3_uint64);
 ** [sqlite3_bind_parameter_name()], and
 ** [sqlite3_bind_parameter_index()].
 */
-SQLITE_API int sqlite3_bind_parameter_count(sqlite3_stmt *);
+SQLITE_API int sqlite3_bind_parameter_count(sqlite3_stmt*);
 
 /*
 ** CAPI3REF: Name Of A Host Parameter
@@ -4745,7 +4742,7 @@ SQLITE_API int sqlite3_bind_parameter_count(sqlite3_stmt *);
 ** [sqlite3_bind_parameter_count()], and
 ** [sqlite3_bind_parameter_index()].
 */
-SQLITE_API const char *sqlite3_bind_parameter_name(sqlite3_stmt *, int);
+SQLITE_API const char *sqlite3_bind_parameter_name(sqlite3_stmt*, int);
 
 /*
 ** CAPI3REF: Index Of A Parameter With A Given Name
@@ -4763,7 +4760,7 @@ SQLITE_API const char *sqlite3_bind_parameter_name(sqlite3_stmt *, int);
 ** [sqlite3_bind_parameter_count()], and
 ** [sqlite3_bind_parameter_name()].
 */
-SQLITE_API int sqlite3_bind_parameter_index(sqlite3_stmt *, const char *zName);
+SQLITE_API int sqlite3_bind_parameter_index(sqlite3_stmt*, const char *zName);
 
 /*
 ** CAPI3REF: Reset All Bindings On A Prepared Statement
@@ -4773,7 +4770,7 @@ SQLITE_API int sqlite3_bind_parameter_index(sqlite3_stmt *, const char *zName);
 ** the [sqlite3_bind_blob | bindings] on a [prepared statement].
 ** ^Use this routine to reset all host parameters to NULL.
 */
-SQLITE_API int sqlite3_clear_bindings(sqlite3_stmt *);
+SQLITE_API int sqlite3_clear_bindings(sqlite3_stmt*);
 
 /*
 ** CAPI3REF: Number Of Columns In A Result Set
@@ -4818,8 +4815,8 @@ SQLITE_API int sqlite3_column_count(sqlite3_stmt *pStmt);
 ** then the name of the column is unspecified and may change from
 ** one release of SQLite to the next.
 */
-SQLITE_API const char *sqlite3_column_name(sqlite3_stmt *, int N);
-SQLITE_API const void *sqlite3_column_name16(sqlite3_stmt *, int N);
+SQLITE_API const char *sqlite3_column_name(sqlite3_stmt*, int N);
+SQLITE_API const void *sqlite3_column_name16(sqlite3_stmt*, int N);
 
 /*
 ** CAPI3REF: Source Of Data In A Query Result
@@ -4863,12 +4860,12 @@ SQLITE_API const void *sqlite3_column_name16(sqlite3_stmt *, int N);
 ** for the same [prepared statement] and result column
 ** at the same time then the results are undefined.
 */
-SQLITE_API const char *sqlite3_column_database_name(sqlite3_stmt *, int);
-SQLITE_API const void *sqlite3_column_database_name16(sqlite3_stmt *, int);
-SQLITE_API const char *sqlite3_column_table_name(sqlite3_stmt *, int);
-SQLITE_API const void *sqlite3_column_table_name16(sqlite3_stmt *, int);
-SQLITE_API const char *sqlite3_column_origin_name(sqlite3_stmt *, int);
-SQLITE_API const void *sqlite3_column_origin_name16(sqlite3_stmt *, int);
+SQLITE_API const char *sqlite3_column_database_name(sqlite3_stmt*,int);
+SQLITE_API const void *sqlite3_column_database_name16(sqlite3_stmt*,int);
+SQLITE_API const char *sqlite3_column_table_name(sqlite3_stmt*,int);
+SQLITE_API const void *sqlite3_column_table_name16(sqlite3_stmt*,int);
+SQLITE_API const char *sqlite3_column_origin_name(sqlite3_stmt*,int);
+SQLITE_API const void *sqlite3_column_origin_name16(sqlite3_stmt*,int);
 
 /*
 ** CAPI3REF: Declared Datatype Of A Query Result
@@ -4900,8 +4897,8 @@ SQLITE_API const void *sqlite3_column_origin_name16(sqlite3_stmt *, int);
 ** is associated with individual values, not with the containers
 ** used to hold those values.
 */
-SQLITE_API const char *sqlite3_column_decltype(sqlite3_stmt *, int);
-SQLITE_API const void *sqlite3_column_decltype16(sqlite3_stmt *, int);
+SQLITE_API const char *sqlite3_column_decltype(sqlite3_stmt*,int);
+SQLITE_API const void *sqlite3_column_decltype16(sqlite3_stmt*,int);
 
 /*
 ** CAPI3REF: Evaluate An SQL Statement
@@ -4985,7 +4982,7 @@ SQLITE_API const void *sqlite3_column_decltype16(sqlite3_stmt *, int);
 ** then the more specific [error codes] are returned directly
 ** by sqlite3_step().  The use of the "vX" interfaces is recommended.
 */
-SQLITE_API int sqlite3_step(sqlite3_stmt *);
+SQLITE_API int sqlite3_step(sqlite3_stmt*);
 
 /*
 ** CAPI3REF: Number of columns in a result set
@@ -5029,16 +5026,16 @@ SQLITE_API int sqlite3_data_count(sqlite3_stmt *pStmt);
 ** SQLite version 2 and SQLite version 3 should use SQLITE3_TEXT, not
 ** SQLITE_TEXT.
 */
-#define SQLITE_INTEGER 1
-#define SQLITE_FLOAT 2
-#define SQLITE_BLOB 4
-#define SQLITE_NULL 5
+#define SQLITE_INTEGER  1
+#define SQLITE_FLOAT    2
+#define SQLITE_BLOB     4
+#define SQLITE_NULL     5
 #ifdef SQLITE_TEXT
-#undef SQLITE_TEXT
+# undef SQLITE_TEXT
 #else
-#define SQLITE_TEXT 3
+# define SQLITE_TEXT     3
 #endif
-#define SQLITE3_TEXT 3
+#define SQLITE3_TEXT     3
 
 /*
 ** CAPI3REF: Result Values From A Query
@@ -5253,16 +5250,16 @@ SQLITE_API int sqlite3_data_count(sqlite3_stmt *pStmt);
 ** return value is obtained and before any
 ** other SQLite interface is called on the same [database connection].
 */
-SQLITE_API const void *sqlite3_column_blob(sqlite3_stmt *, int iCol);
-SQLITE_API double sqlite3_column_double(sqlite3_stmt *, int iCol);
-SQLITE_API int sqlite3_column_int(sqlite3_stmt *, int iCol);
-SQLITE_API sqlite3_int64 sqlite3_column_int64(sqlite3_stmt *, int iCol);
-SQLITE_API const unsigned char *sqlite3_column_text(sqlite3_stmt *, int iCol);
-SQLITE_API const void *sqlite3_column_text16(sqlite3_stmt *, int iCol);
-SQLITE_API sqlite3_value *sqlite3_column_value(sqlite3_stmt *, int iCol);
-SQLITE_API int sqlite3_column_bytes(sqlite3_stmt *, int iCol);
-SQLITE_API int sqlite3_column_bytes16(sqlite3_stmt *, int iCol);
-SQLITE_API int sqlite3_column_type(sqlite3_stmt *, int iCol);
+SQLITE_API const void *sqlite3_column_blob(sqlite3_stmt*, int iCol);
+SQLITE_API double sqlite3_column_double(sqlite3_stmt*, int iCol);
+SQLITE_API int sqlite3_column_int(sqlite3_stmt*, int iCol);
+SQLITE_API sqlite3_int64 sqlite3_column_int64(sqlite3_stmt*, int iCol);
+SQLITE_API const unsigned char *sqlite3_column_text(sqlite3_stmt*, int iCol);
+SQLITE_API const void *sqlite3_column_text16(sqlite3_stmt*, int iCol);
+SQLITE_API sqlite3_value *sqlite3_column_value(sqlite3_stmt*, int iCol);
+SQLITE_API int sqlite3_column_bytes(sqlite3_stmt*, int iCol);
+SQLITE_API int sqlite3_column_bytes16(sqlite3_stmt*, int iCol);
+SQLITE_API int sqlite3_column_type(sqlite3_stmt*, int iCol);
 
 /*
 ** CAPI3REF: Destroy A Prepared Statement Object
@@ -5330,6 +5327,7 @@ SQLITE_API int sqlite3_finalize(sqlite3_stmt *pStmt);
 ** of any [sqlite3_bind_blob|bindings] on the [prepared statement] S.
 */
 SQLITE_API int sqlite3_reset(sqlite3_stmt *pStmt);
+
 
 /*
 ** CAPI3REF: Create Or Redefine SQL Functions
@@ -5454,28 +5452,49 @@ SQLITE_API int sqlite3_reset(sqlite3_stmt *pStmt);
 ** close the database connection nor finalize or reset the prepared
 ** statement in which the function is running.
 */
-SQLITE_API int
-sqlite3_create_function(sqlite3 *db, const char *zFunctionName, int nArg,
-                        int eTextRep, void *pApp,
-                        void (*xFunc)(sqlite3_context *, int, sqlite3_value **),
-                        void (*xStep)(sqlite3_context *, int, sqlite3_value **),
-                        void (*xFinal)(sqlite3_context *));
+SQLITE_API int sqlite3_create_function(
+  sqlite3 *db,
+  const char *zFunctionName,
+  int nArg,
+  int eTextRep,
+  void *pApp,
+  void (*xFunc)(sqlite3_context*,int,sqlite3_value**),
+  void (*xStep)(sqlite3_context*,int,sqlite3_value**),
+  void (*xFinal)(sqlite3_context*)
+);
 SQLITE_API int sqlite3_create_function16(
-    sqlite3 *db, const void *zFunctionName, int nArg, int eTextRep, void *pApp,
-    void (*xFunc)(sqlite3_context *, int, sqlite3_value **),
-    void (*xStep)(sqlite3_context *, int, sqlite3_value **),
-    void (*xFinal)(sqlite3_context *));
+  sqlite3 *db,
+  const void *zFunctionName,
+  int nArg,
+  int eTextRep,
+  void *pApp,
+  void (*xFunc)(sqlite3_context*,int,sqlite3_value**),
+  void (*xStep)(sqlite3_context*,int,sqlite3_value**),
+  void (*xFinal)(sqlite3_context*)
+);
 SQLITE_API int sqlite3_create_function_v2(
-    sqlite3 *db, const char *zFunctionName, int nArg, int eTextRep, void *pApp,
-    void (*xFunc)(sqlite3_context *, int, sqlite3_value **),
-    void (*xStep)(sqlite3_context *, int, sqlite3_value **),
-    void (*xFinal)(sqlite3_context *), void (*xDestroy)(void *));
+  sqlite3 *db,
+  const char *zFunctionName,
+  int nArg,
+  int eTextRep,
+  void *pApp,
+  void (*xFunc)(sqlite3_context*,int,sqlite3_value**),
+  void (*xStep)(sqlite3_context*,int,sqlite3_value**),
+  void (*xFinal)(sqlite3_context*),
+  void(*xDestroy)(void*)
+);
 SQLITE_API int sqlite3_create_window_function(
-    sqlite3 *db, const char *zFunctionName, int nArg, int eTextRep, void *pApp,
-    void (*xStep)(sqlite3_context *, int, sqlite3_value **),
-    void (*xFinal)(sqlite3_context *), void (*xValue)(sqlite3_context *),
-    void (*xInverse)(sqlite3_context *, int, sqlite3_value **),
-    void (*xDestroy)(void *));
+  sqlite3 *db,
+  const char *zFunctionName,
+  int nArg,
+  int eTextRep,
+  void *pApp,
+  void (*xStep)(sqlite3_context*,int,sqlite3_value**),
+  void (*xFinal)(sqlite3_context*),
+  void (*xValue)(sqlite3_context*),
+  void (*xInverse)(sqlite3_context*,int,sqlite3_value**),
+  void(*xDestroy)(void*)
+);
 
 /*
 ** CAPI3REF: Text Encodings
@@ -5483,12 +5502,12 @@ SQLITE_API int sqlite3_create_window_function(
 ** These constant define integer codes that represent the various
 ** text encodings supported by SQLite.
 */
-#define SQLITE_UTF8 1          /* IMP: R-37514-35566 */
-#define SQLITE_UTF16LE 2       /* IMP: R-03371-37637 */
-#define SQLITE_UTF16BE 3       /* IMP: R-51971-34154 */
-#define SQLITE_UTF16 4         /* Use native byte order */
-#define SQLITE_ANY 5           /* Deprecated */
-#define SQLITE_UTF16_ALIGNED 8 /* sqlite3_create_collation only */
+#define SQLITE_UTF8           1    /* IMP: R-37514-35566 */
+#define SQLITE_UTF16LE        2    /* IMP: R-03371-37637 */
+#define SQLITE_UTF16BE        3    /* IMP: R-51971-34154 */
+#define SQLITE_UTF16          4    /* Use native byte order */
+#define SQLITE_ANY            5    /* Deprecated */
+#define SQLITE_UTF16_ALIGNED  8    /* sqlite3_create_collation only */
 
 /*
 ** CAPI3REF: Function Flags
@@ -5556,20 +5575,35 @@ SQLITE_API int sqlite3_create_window_function(
 ** </dd>
 **
 ** [[SQLITE_SUBTYPE]] <dt>SQLITE_SUBTYPE</dt><dd>
-** The SQLITE_SUBTYPE flag indicates to SQLite that a function may call
+** The SQLITE_SUBTYPE flag indicates to SQLite that a function might call
 ** [sqlite3_value_subtype()] to inspect the sub-types of its arguments.
-** Specifying this flag makes no difference for scalar or aggregate user
-** functions. However, if it is not specified for a user-defined window
-** function, then any sub-types belonging to arguments passed to the window
-** function may be discarded before the window function is called (i.e.
-** sqlite3_value_subtype() will always return 0).
+** This flag instructs SQLite to omit some corner-case optimizations that
+** might disrupt the operation of the [sqlite3_value_subtype()] function,
+** causing it to return zero rather than the correct subtype().
+** SQL functions that invokes [sqlite3_value_subtype()] should have this
+** property.  If the SQLITE_SUBTYPE property is omitted, then the return
+** value from [sqlite3_value_subtype()] might sometimes be zero even though
+** a non-zero subtype was specified by the function argument expression.
+**
+** [[SQLITE_RESULT_SUBTYPE]] <dt>SQLITE_RESULT_SUBTYPE</dt><dd>
+** The SQLITE_RESULT_SUBTYPE flag indicates to SQLite that a function might call
+** [sqlite3_result_subtype()] to cause a sub-type to be associated with its
+** result.
+** Every function that invokes [sqlite3_result_subtype()] should have this
+** property.  If it does not, then the call to [sqlite3_result_subtype()]
+** might become a no-op if the function is used as term in an
+** [expression index].  On the other hand, SQL functions that never invoke
+** [sqlite3_result_subtype()] should avoid setting this property, as the
+** purpose of this property is to disable certain optimizations that are
+** incompatible with subtypes.
 ** </dd>
 ** </dl>
 */
-#define SQLITE_DETERMINISTIC 0x000000800
-#define SQLITE_DIRECTONLY 0x000080000
-#define SQLITE_SUBTYPE 0x000100000
-#define SQLITE_INNOCUOUS 0x000200000
+#define SQLITE_DETERMINISTIC    0x000000800
+#define SQLITE_DIRECTONLY       0x000080000
+#define SQLITE_SUBTYPE          0x000100000
+#define SQLITE_INNOCUOUS        0x000200000
+#define SQLITE_RESULT_SUBTYPE   0x001000000
 
 /*
 ** CAPI3REF: Deprecated Functions
@@ -5582,15 +5616,13 @@ SQLITE_API int sqlite3_create_window_function(
 ** these functions, we will not explain what they do.
 */
 #ifndef SQLITE_OMIT_DEPRECATED
-SQLITE_API SQLITE_DEPRECATED int sqlite3_aggregate_count(sqlite3_context *);
-SQLITE_API SQLITE_DEPRECATED int sqlite3_expired(sqlite3_stmt *);
-SQLITE_API SQLITE_DEPRECATED int sqlite3_transfer_bindings(sqlite3_stmt *,
-                                                           sqlite3_stmt *);
+SQLITE_API SQLITE_DEPRECATED int sqlite3_aggregate_count(sqlite3_context*);
+SQLITE_API SQLITE_DEPRECATED int sqlite3_expired(sqlite3_stmt*);
+SQLITE_API SQLITE_DEPRECATED int sqlite3_transfer_bindings(sqlite3_stmt*, sqlite3_stmt*);
 SQLITE_API SQLITE_DEPRECATED int sqlite3_global_recover(void);
 SQLITE_API SQLITE_DEPRECATED void sqlite3_thread_cleanup(void);
-SQLITE_API SQLITE_DEPRECATED int
-sqlite3_memory_alarm(void (*)(void *, sqlite3_int64, int), void *,
-                     sqlite3_int64);
+SQLITE_API SQLITE_DEPRECATED int sqlite3_memory_alarm(void(*)(void*,sqlite3_int64,int),
+                      void*,sqlite3_int64);
 #endif
 
 /*
@@ -5721,21 +5753,21 @@ sqlite3_memory_alarm(void (*)(void *, sqlite3_int64, int), void *,
 ** return value is obtained and before any
 ** other SQLite interface is called on the same [database connection].
 */
-SQLITE_API const void *sqlite3_value_blob(sqlite3_value *);
-SQLITE_API double sqlite3_value_double(sqlite3_value *);
-SQLITE_API int sqlite3_value_int(sqlite3_value *);
-SQLITE_API sqlite3_int64 sqlite3_value_int64(sqlite3_value *);
-SQLITE_API void *sqlite3_value_pointer(sqlite3_value *, const char *);
-SQLITE_API const unsigned char *sqlite3_value_text(sqlite3_value *);
-SQLITE_API const void *sqlite3_value_text16(sqlite3_value *);
-SQLITE_API const void *sqlite3_value_text16le(sqlite3_value *);
-SQLITE_API const void *sqlite3_value_text16be(sqlite3_value *);
-SQLITE_API int sqlite3_value_bytes(sqlite3_value *);
-SQLITE_API int sqlite3_value_bytes16(sqlite3_value *);
-SQLITE_API int sqlite3_value_type(sqlite3_value *);
-SQLITE_API int sqlite3_value_numeric_type(sqlite3_value *);
-SQLITE_API int sqlite3_value_nochange(sqlite3_value *);
-SQLITE_API int sqlite3_value_frombind(sqlite3_value *);
+SQLITE_API const void *sqlite3_value_blob(sqlite3_value*);
+SQLITE_API double sqlite3_value_double(sqlite3_value*);
+SQLITE_API int sqlite3_value_int(sqlite3_value*);
+SQLITE_API sqlite3_int64 sqlite3_value_int64(sqlite3_value*);
+SQLITE_API void *sqlite3_value_pointer(sqlite3_value*, const char*);
+SQLITE_API const unsigned char *sqlite3_value_text(sqlite3_value*);
+SQLITE_API const void *sqlite3_value_text16(sqlite3_value*);
+SQLITE_API const void *sqlite3_value_text16le(sqlite3_value*);
+SQLITE_API const void *sqlite3_value_text16be(sqlite3_value*);
+SQLITE_API int sqlite3_value_bytes(sqlite3_value*);
+SQLITE_API int sqlite3_value_bytes16(sqlite3_value*);
+SQLITE_API int sqlite3_value_type(sqlite3_value*);
+SQLITE_API int sqlite3_value_numeric_type(sqlite3_value*);
+SQLITE_API int sqlite3_value_nochange(sqlite3_value*);
+SQLITE_API int sqlite3_value_frombind(sqlite3_value*);
 
 /*
 ** CAPI3REF: Report the internal text encoding state of an sqlite3_value object
@@ -5746,8 +5778,7 @@ SQLITE_API int sqlite3_value_frombind(sqlite3_value *);
 ** of the value X, assuming that X has type TEXT.)^  If sqlite3_value_type(X)
 ** returns something other than SQLITE_TEXT, then the return value from
 ** sqlite3_value_encoding(X) is meaningless.  ^Calls to
-** [sqlite3_value_text(X)], [sqlite3_value_text16(X)],
-*[sqlite3_value_text16be(X)],
+** [sqlite3_value_text(X)], [sqlite3_value_text16(X)], [sqlite3_value_text16be(X)],
 ** [sqlite3_value_text16le(X)], [sqlite3_value_bytes(X)], or
 ** [sqlite3_value_bytes16(X)] might change the encoding of the value X and
 ** thus change the return from subsequent calls to sqlite3_value_encoding(X).
@@ -5758,7 +5789,7 @@ SQLITE_API int sqlite3_value_frombind(sqlite3_value *);
 ** not need to know what the internal state of an sqlite3_value object is and
 ** hence should not need to use this interface.
 */
-SQLITE_API int sqlite3_value_encoding(sqlite3_value *);
+SQLITE_API int sqlite3_value_encoding(sqlite3_value*);
 
 /*
 ** CAPI3REF: Finding The Subtype Of SQL Values
@@ -5769,8 +5800,14 @@ SQLITE_API int sqlite3_value_encoding(sqlite3_value *);
 ** information can be used to pass a limited amount of context from
 ** one SQL function to another.  Use the [sqlite3_result_subtype()]
 ** routine to set the subtype for the return value of an SQL function.
+**
+** Every [application-defined SQL function] that invoke this interface
+** should include the [SQLITE_SUBTYPE] property in the text
+** encoding argument when the function is [sqlite3_create_function|registered].
+** If the [SQLITE_SUBTYPE] property is omitted, then sqlite3_value_subtype()
+** might return zero instead of the upstream subtype in some corner cases.
 */
-SQLITE_API unsigned int sqlite3_value_subtype(sqlite3_value *);
+SQLITE_API unsigned int sqlite3_value_subtype(sqlite3_value*);
 
 /*
 ** CAPI3REF: Copy And Free SQL Values
@@ -5787,8 +5824,8 @@ SQLITE_API unsigned int sqlite3_value_subtype(sqlite3_value *);
 ** previously obtained from [sqlite3_value_dup()].  ^If V is a NULL pointer
 ** then sqlite3_value_free(V) is a harmless no-op.
 */
-SQLITE_API sqlite3_value *sqlite3_value_dup(const sqlite3_value *);
-SQLITE_API void sqlite3_value_free(sqlite3_value *);
+SQLITE_API sqlite3_value *sqlite3_value_dup(const sqlite3_value*);
+SQLITE_API void sqlite3_value_free(sqlite3_value*);
 
 /*
 ** CAPI3REF: Obtain Aggregate Function Context
@@ -5833,7 +5870,7 @@ SQLITE_API void sqlite3_value_free(sqlite3_value *);
 ** This routine must be called from the same thread in which
 ** the aggregate SQL function is running.
 */
-SQLITE_API void *sqlite3_aggregate_context(sqlite3_context *, int nBytes);
+SQLITE_API void *sqlite3_aggregate_context(sqlite3_context*, int nBytes);
 
 /*
 ** CAPI3REF: User Data For Functions
@@ -5848,7 +5885,7 @@ SQLITE_API void *sqlite3_aggregate_context(sqlite3_context *, int nBytes);
 ** This routine must be called from the same thread in which
 ** the application-defined function is running.
 */
-SQLITE_API void *sqlite3_user_data(sqlite3_context *);
+SQLITE_API void *sqlite3_user_data(sqlite3_context*);
 
 /*
 ** CAPI3REF: Database Connection For Functions
@@ -5860,7 +5897,7 @@ SQLITE_API void *sqlite3_user_data(sqlite3_context *);
 ** and [sqlite3_create_function16()] routines that originally
 ** registered the application defined function.
 */
-SQLITE_API sqlite3 *sqlite3_context_db_handle(sqlite3_context *);
+SQLITE_API sqlite3 *sqlite3_context_db_handle(sqlite3_context*);
 
 /*
 ** CAPI3REF: Function Auxiliary Data
@@ -5872,14 +5909,12 @@ SQLITE_API sqlite3 *sqlite3_context_db_handle(sqlite3_context *);
 ** query execution, under some circumstances the associated auxiliary data
 ** might be preserved.  An example of where this might be useful is in a
 ** regular-expression matching function. The compiled version of the regular
-** expression can be stored as auxiliary data associated with the pattern
-*string.
+** expression can be stored as auxiliary data associated with the pattern string.
 ** Then as long as the pattern string remains the same,
 ** the compiled regular expression can be reused on multiple
 ** invocations of the same function.
 **
-** ^The sqlite3_get_auxdata(C,N) interface returns a pointer to the auxiliary
-*data
+** ^The sqlite3_get_auxdata(C,N) interface returns a pointer to the auxiliary data
 ** associated by the sqlite3_set_auxdata(C,N,P,X) function with the Nth argument
 ** value to the application-defined function.  ^N is zero for the left-most
 ** function argument.  ^If there is no auxiliary data
@@ -5901,14 +5936,22 @@ SQLITE_API sqlite3 *sqlite3_context_db_handle(sqlite3_context *);
 ** <li> ^(when sqlite3_set_auxdata() is invoked again on the same
 **       parameter)^, or
 ** <li> ^(during the original sqlite3_set_auxdata() call when a memory
-**      allocation error occurs.)^ </ul>
+**      allocation error occurs.)^
+** <li> ^(during the original sqlite3_set_auxdata() call if the function
+**      is evaluated during query planning instead of during query execution,
+**      as sometimes happens with [SQLITE_ENABLE_STAT4].)^ </ul>
 **
-** Note the last bullet in particular.  The destructor X in
+** Note the last two bullets in particular.  The destructor X in
 ** sqlite3_set_auxdata(C,N,P,X) might be called immediately, before the
 ** sqlite3_set_auxdata() interface even returns.  Hence sqlite3_set_auxdata()
 ** should be called near the end of the function implementation and the
 ** function implementation should not make any use of P after
-** sqlite3_set_auxdata() has been called.
+** sqlite3_set_auxdata() has been called.  Furthermore, a call to
+** sqlite3_get_auxdata() that occurs immediately after a corresponding call
+** to sqlite3_set_auxdata() might still return NULL if an out-of-memory
+** condition occurred during the sqlite3_set_auxdata() call or if the
+** function is being evaluated during query planning rather than during
+** query execution.
 **
 ** ^(In practice, auxiliary data is preserved between function calls for
 ** function parameters that are compile-time constants, including literal
@@ -5923,9 +5966,8 @@ SQLITE_API sqlite3 *sqlite3_context_db_handle(sqlite3_context *);
 **
 ** See also: [sqlite3_get_clientdata()] and [sqlite3_set_clientdata()].
 */
-SQLITE_API void *sqlite3_get_auxdata(sqlite3_context *, int N);
-SQLITE_API void sqlite3_set_auxdata(sqlite3_context *, int N, void *,
-                                    void (*)(void *));
+SQLITE_API void *sqlite3_get_auxdata(sqlite3_context*, int N);
+SQLITE_API void sqlite3_set_auxdata(sqlite3_context*, int N, void*, void (*)(void*));
 
 /*
 ** CAPI3REF: Database Connection Client Data
@@ -5980,9 +6022,8 @@ SQLITE_API void sqlite3_set_auxdata(sqlite3_context *, int N, void *,
 **
 ** See also: [sqlite3_set_auxdata()] and [sqlite3_get_auxdata()].
 */
-SQLITE_API void *sqlite3_get_clientdata(sqlite3 *, const char *);
-SQLITE_API int sqlite3_set_clientdata(sqlite3 *, const char *, void *,
-                                      void (*)(void *));
+SQLITE_API void *sqlite3_get_clientdata(sqlite3*,const char*);
+SQLITE_API int sqlite3_set_clientdata(sqlite3*, const char*, void*, void(*)(void*));
 
 /*
 ** CAPI3REF: Constants Defining Special Destructor Behavior
@@ -5998,9 +6039,9 @@ SQLITE_API int sqlite3_set_clientdata(sqlite3 *, const char *, void *,
 ** The typedef is necessary to work around problems in certain
 ** C++ compilers.
 */
-typedef void (*sqlite3_destructor_type)(void *);
-#define SQLITE_STATIC ((sqlite3_destructor_type)0)
-#define SQLITE_TRANSIENT ((sqlite3_destructor_type)-1)
+typedef void (*sqlite3_destructor_type)(void*);
+#define SQLITE_STATIC      ((sqlite3_destructor_type)0)
+#define SQLITE_TRANSIENT   ((sqlite3_destructor_type)-1)
 
 /*
 ** CAPI3REF: Setting The Result Of An SQL Function
@@ -6149,35 +6190,29 @@ typedef void (*sqlite3_destructor_type)(void *);
 ** than the one containing the application-defined function that received
 ** the [sqlite3_context] pointer, the results are undefined.
 */
-SQLITE_API void sqlite3_result_blob(sqlite3_context *, const void *, int,
-                                    void (*)(void *));
-SQLITE_API void sqlite3_result_blob64(sqlite3_context *, const void *,
-                                      sqlite3_uint64, void (*)(void *));
-SQLITE_API void sqlite3_result_double(sqlite3_context *, double);
-SQLITE_API void sqlite3_result_error(sqlite3_context *, const char *, int);
-SQLITE_API void sqlite3_result_error16(sqlite3_context *, const void *, int);
-SQLITE_API void sqlite3_result_error_toobig(sqlite3_context *);
-SQLITE_API void sqlite3_result_error_nomem(sqlite3_context *);
-SQLITE_API void sqlite3_result_error_code(sqlite3_context *, int);
-SQLITE_API void sqlite3_result_int(sqlite3_context *, int);
-SQLITE_API void sqlite3_result_int64(sqlite3_context *, sqlite3_int64);
-SQLITE_API void sqlite3_result_null(sqlite3_context *);
-SQLITE_API void sqlite3_result_text(sqlite3_context *, const char *, int,
-                                    void (*)(void *));
-SQLITE_API void sqlite3_result_text64(sqlite3_context *, const char *,
-                                      sqlite3_uint64, void (*)(void *),
-                                      unsigned char encoding);
-SQLITE_API void sqlite3_result_text16(sqlite3_context *, const void *, int,
-                                      void (*)(void *));
-SQLITE_API void sqlite3_result_text16le(sqlite3_context *, const void *, int,
-                                        void (*)(void *));
-SQLITE_API void sqlite3_result_text16be(sqlite3_context *, const void *, int,
-                                        void (*)(void *));
-SQLITE_API void sqlite3_result_value(sqlite3_context *, sqlite3_value *);
-SQLITE_API void sqlite3_result_pointer(sqlite3_context *, void *, const char *,
-                                       void (*)(void *));
-SQLITE_API void sqlite3_result_zeroblob(sqlite3_context *, int n);
-SQLITE_API int sqlite3_result_zeroblob64(sqlite3_context *, sqlite3_uint64 n);
+SQLITE_API void sqlite3_result_blob(sqlite3_context*, const void*, int, void(*)(void*));
+SQLITE_API void sqlite3_result_blob64(sqlite3_context*,const void*,
+                           sqlite3_uint64,void(*)(void*));
+SQLITE_API void sqlite3_result_double(sqlite3_context*, double);
+SQLITE_API void sqlite3_result_error(sqlite3_context*, const char*, int);
+SQLITE_API void sqlite3_result_error16(sqlite3_context*, const void*, int);
+SQLITE_API void sqlite3_result_error_toobig(sqlite3_context*);
+SQLITE_API void sqlite3_result_error_nomem(sqlite3_context*);
+SQLITE_API void sqlite3_result_error_code(sqlite3_context*, int);
+SQLITE_API void sqlite3_result_int(sqlite3_context*, int);
+SQLITE_API void sqlite3_result_int64(sqlite3_context*, sqlite3_int64);
+SQLITE_API void sqlite3_result_null(sqlite3_context*);
+SQLITE_API void sqlite3_result_text(sqlite3_context*, const char*, int, void(*)(void*));
+SQLITE_API void sqlite3_result_text64(sqlite3_context*, const char*,sqlite3_uint64,
+                           void(*)(void*), unsigned char encoding);
+SQLITE_API void sqlite3_result_text16(sqlite3_context*, const void*, int, void(*)(void*));
+SQLITE_API void sqlite3_result_text16le(sqlite3_context*, const void*, int,void(*)(void*));
+SQLITE_API void sqlite3_result_text16be(sqlite3_context*, const void*, int,void(*)(void*));
+SQLITE_API void sqlite3_result_value(sqlite3_context*, sqlite3_value*);
+SQLITE_API void sqlite3_result_pointer(sqlite3_context*, void*,const char*,void(*)(void*));
+SQLITE_API void sqlite3_result_zeroblob(sqlite3_context*, int n);
+SQLITE_API int sqlite3_result_zeroblob64(sqlite3_context*, sqlite3_uint64 n);
+
 
 /*
 ** CAPI3REF: Setting The Subtype Of An SQL Function
@@ -6190,8 +6225,22 @@ SQLITE_API int sqlite3_result_zeroblob64(sqlite3_context *, sqlite3_uint64 n);
 ** higher order bits are discarded.
 ** The number of subtype bytes preserved by SQLite might increase
 ** in future releases of SQLite.
+**
+** Every [application-defined SQL function] that invokes this interface
+** should include the [SQLITE_RESULT_SUBTYPE] property in its
+** text encoding argument when the SQL function is
+** [sqlite3_create_function|registered].  If the [SQLITE_RESULT_SUBTYPE]
+** property is omitted from the function that invokes sqlite3_result_subtype(),
+** then in some cases the sqlite3_result_subtype() might fail to set
+** the result subtype.
+**
+** If SQLite is compiled with -DSQLITE_STRICT_SUBTYPE=1, then any
+** SQL function that invokes the sqlite3_result_subtype() interface
+** and that does not have the SQLITE_RESULT_SUBTYPE property will raise
+** an error.  Future versions of SQLite might enable -DSQLITE_STRICT_SUBTYPE=1
+** by default.
 */
-SQLITE_API void sqlite3_result_subtype(sqlite3_context *, unsigned int);
+SQLITE_API void sqlite3_result_subtype(sqlite3_context*,unsigned int);
 
 /*
 ** CAPI3REF: Define New Collating Sequences
@@ -6275,15 +6324,27 @@ SQLITE_API void sqlite3_result_subtype(sqlite3_context *, unsigned int);
 ** See also:  [sqlite3_collation_needed()] and [sqlite3_collation_needed16()].
 */
 SQLITE_API int sqlite3_create_collation(
-    sqlite3 *, const char *zName, int eTextRep, void *pArg,
-    int (*xCompare)(void *, int, const void *, int, const void *));
+  sqlite3*,
+  const char *zName,
+  int eTextRep,
+  void *pArg,
+  int(*xCompare)(void*,int,const void*,int,const void*)
+);
 SQLITE_API int sqlite3_create_collation_v2(
-    sqlite3 *, const char *zName, int eTextRep, void *pArg,
-    int (*xCompare)(void *, int, const void *, int, const void *),
-    void (*xDestroy)(void *));
+  sqlite3*,
+  const char *zName,
+  int eTextRep,
+  void *pArg,
+  int(*xCompare)(void*,int,const void*,int,const void*),
+  void(*xDestroy)(void*)
+);
 SQLITE_API int sqlite3_create_collation16(
-    sqlite3 *, const void *zName, int eTextRep, void *pArg,
-    int (*xCompare)(void *, int, const void *, int, const void *));
+  sqlite3*,
+  const void *zName,
+  int eTextRep,
+  void *pArg,
+  int(*xCompare)(void*,int,const void*,int,const void*)
+);
 
 /*
 ** CAPI3REF: Collation Needed Callbacks
@@ -6312,20 +6373,24 @@ SQLITE_API int sqlite3_create_collation16(
 ** [sqlite3_create_collation()], [sqlite3_create_collation16()], or
 ** [sqlite3_create_collation_v2()].
 */
-SQLITE_API int sqlite3_collation_needed(sqlite3 *, void *,
-                                        void (*)(void *, sqlite3 *,
-                                                 int eTextRep, const char *));
-SQLITE_API int sqlite3_collation_needed16(sqlite3 *, void *,
-                                          void (*)(void *, sqlite3 *,
-                                                   int eTextRep, const void *));
+SQLITE_API int sqlite3_collation_needed(
+  sqlite3*,
+  void*,
+  void(*)(void*,sqlite3*,int eTextRep,const char*)
+);
+SQLITE_API int sqlite3_collation_needed16(
+  sqlite3*,
+  void*,
+  void(*)(void*,sqlite3*,int eTextRep,const void*)
+);
 
 #ifdef SQLITE_ENABLE_CEROD
 /*
 ** Specify the activation key for a CEROD database.  Unless
 ** activated, none of the CEROD routines will work.
 */
-SQLITE_API void
-sqlite3_activate_cerod(const char *zPassPhrase /* Activation phrase */
+SQLITE_API void sqlite3_activate_cerod(
+  const char *zPassPhrase        /* Activation phrase */
 );
 #endif
 
@@ -6470,13 +6535,11 @@ SQLITE_API SQLITE_EXTERN char *sqlite3_data_directory;
 ** UTF-8 or UTF-16, respectively.
 */
 SQLITE_API int sqlite3_win32_set_directory(
-    unsigned long type, /* Identifier for directory being set or reset */
-    void *zValue        /* New value for directory being set or reset */
+  unsigned long type, /* Identifier for directory being set or reset */
+  void *zValue        /* New value for directory being set or reset */
 );
-SQLITE_API int sqlite3_win32_set_directory8(unsigned long type,
-                                            const char *zValue);
-SQLITE_API int sqlite3_win32_set_directory16(unsigned long type,
-                                             const void *zValue);
+SQLITE_API int sqlite3_win32_set_directory8(unsigned long type, const char *zValue);
+SQLITE_API int sqlite3_win32_set_directory16(unsigned long type, const void *zValue);
 
 /*
 ** CAPI3REF: Win32 Directory Types
@@ -6484,8 +6547,8 @@ SQLITE_API int sqlite3_win32_set_directory16(unsigned long type,
 ** These macros are only available on Windows.  They define the allowed values
 ** for the type argument to the [sqlite3_win32_set_directory] interface.
 */
-#define SQLITE_WIN32_DATA_DIRECTORY_TYPE 1
-#define SQLITE_WIN32_TEMP_DIRECTORY_TYPE 2
+#define SQLITE_WIN32_DATA_DIRECTORY_TYPE  1
+#define SQLITE_WIN32_TEMP_DIRECTORY_TYPE  2
 
 /*
 ** CAPI3REF: Test For Auto-Commit Mode
@@ -6509,7 +6572,7 @@ SQLITE_API int sqlite3_win32_set_directory16(unsigned long type,
 ** connection while this routine is running, then the return value
 ** is undefined.
 */
-SQLITE_API int sqlite3_get_autocommit(sqlite3 *);
+SQLITE_API int sqlite3_get_autocommit(sqlite3*);
 
 /*
 ** CAPI3REF: Find The Database Handle Of A Prepared Statement
@@ -6522,7 +6585,7 @@ SQLITE_API int sqlite3_get_autocommit(sqlite3 *);
 ** to the [sqlite3_prepare_v2()] call (or its variants) that was used to
 ** create the statement in the first place.
 */
-SQLITE_API sqlite3 *sqlite3_db_handle(sqlite3_stmt *);
+SQLITE_API sqlite3 *sqlite3_db_handle(sqlite3_stmt*);
 
 /*
 ** CAPI3REF: Return The Schema Name For A Database Connection
@@ -6576,8 +6639,7 @@ SQLITE_API const char *sqlite3_db_name(sqlite3 *db, int N);
 ** <li> [sqlite3_filename_wal()]
 ** </ul>
 */
-SQLITE_API sqlite3_filename sqlite3_db_filename(sqlite3 *db,
-                                                const char *zDbName);
+SQLITE_API sqlite3_filename sqlite3_db_filename(sqlite3 *db, const char *zDbName);
 
 /*
 ** CAPI3REF: Determine if a database is read-only
@@ -6605,7 +6667,7 @@ SQLITE_API int sqlite3_db_readonly(sqlite3 *db, const char *zDbName);
 ** ^If the S argument to sqlite3_txn_state(D,S) is not the name of
 ** a valid schema, then -1 is returned.
 */
-SQLITE_API int sqlite3_txn_state(sqlite3 *, const char *zSchema);
+SQLITE_API int sqlite3_txn_state(sqlite3*,const char *zSchema);
 
 /*
 ** CAPI3REF: Allowed return values from sqlite3_txn_state()
@@ -6636,8 +6698,8 @@ SQLITE_API int sqlite3_txn_state(sqlite3 *, const char *zSchema);
 ** but has not yet committed.  The transaction state will change to
 ** to SQLITE_TXN_NONE at the next [ROLLBACK] or [COMMIT].</dd>
 */
-#define SQLITE_TXN_NONE 0
-#define SQLITE_TXN_READ 1
+#define SQLITE_TXN_NONE  0
+#define SQLITE_TXN_READ  1
 #define SQLITE_TXN_WRITE 2
 
 /*
@@ -6703,8 +6765,8 @@ SQLITE_API sqlite3_stmt *sqlite3_next_stmt(sqlite3 *pDb, sqlite3_stmt *pStmt);
 **
 ** See also the [sqlite3_update_hook()] interface.
 */
-SQLITE_API void *sqlite3_commit_hook(sqlite3 *, int (*)(void *), void *);
-SQLITE_API void *sqlite3_rollback_hook(sqlite3 *, void (*)(void *), void *);
+SQLITE_API void *sqlite3_commit_hook(sqlite3*, int(*)(void*), void*);
+SQLITE_API void *sqlite3_rollback_hook(sqlite3*, void(*)(void *), void*);
 
 /*
 ** CAPI3REF: Autovacuum Compaction Amount Callback
@@ -6764,11 +6826,13 @@ SQLITE_API void *sqlite3_rollback_hook(sqlite3 *, void (*)(void *), void *);
 ** &nbsp;   }
 ** </pre></blockquote>
 */
-SQLITE_API int
-sqlite3_autovacuum_pages(sqlite3 *db,
-                         unsigned int (*)(void *, const char *, unsigned int,
-                                          unsigned int, unsigned int),
-                         void *, void (*)(void *));
+SQLITE_API int sqlite3_autovacuum_pages(
+  sqlite3 *db,
+  unsigned int(*)(void*,const char*,unsigned int,unsigned int,unsigned int),
+  void*,
+  void(*)(void*)
+);
+
 
 /*
 ** CAPI3REF: Data Change Notification Callbacks
@@ -6819,10 +6883,11 @@ sqlite3_autovacuum_pages(sqlite3 *db,
 ** See also the [sqlite3_commit_hook()], [sqlite3_rollback_hook()],
 ** and [sqlite3_preupdate_hook()] interfaces.
 */
-SQLITE_API void *sqlite3_update_hook(sqlite3 *,
-                                     void (*)(void *, int, char const *,
-                                              char const *, sqlite3_int64),
-                                     void *);
+SQLITE_API void *sqlite3_update_hook(
+  sqlite3*,
+  void(*)(void *,int ,char const *,char const *,sqlite3_int64),
+  void*
+);
 
 /*
 ** CAPI3REF: Enable Or Disable Shared Pager Cache
@@ -6898,7 +6963,7 @@ SQLITE_API int sqlite3_release_memory(int);
 **
 ** See also: [sqlite3_release_memory()]
 */
-SQLITE_API int sqlite3_db_release_memory(sqlite3 *);
+SQLITE_API int sqlite3_db_release_memory(sqlite3*);
 
 /*
 ** CAPI3REF: Impose A Limit On Heap Size
@@ -6978,6 +7043,7 @@ SQLITE_API sqlite3_int64 sqlite3_hard_heap_limit64(sqlite3_int64 N);
 */
 SQLITE_API SQLITE_DEPRECATED void sqlite3_soft_heap_limit(int N);
 
+
 /*
 ** CAPI3REF: Extract Metadata About A Column Of A Table
 ** METHOD: sqlite3
@@ -7048,15 +7114,15 @@ SQLITE_API SQLITE_DEPRECATED void sqlite3_soft_heap_limit(int N);
 ** any errors are encountered while loading the schema.
 */
 SQLITE_API int sqlite3_table_column_metadata(
-    sqlite3 *db,             /* Connection handle */
-    const char *zDbName,     /* Database name or NULL */
-    const char *zTableName,  /* Table name */
-    const char *zColumnName, /* Column name */
-    char const **pzDataType, /* OUTPUT: Declared data type */
-    char const **pzCollSeq,  /* OUTPUT: Collation sequence name */
-    int *pNotNull,           /* OUTPUT: True if NOT NULL constraint exists */
-    int *pPrimaryKey,        /* OUTPUT: True if column part of PK */
-    int *pAutoinc            /* OUTPUT: True if column is auto-increment */
+  sqlite3 *db,                /* Connection handle */
+  const char *zDbName,        /* Database name or NULL */
+  const char *zTableName,     /* Table name */
+  const char *zColumnName,    /* Column name */
+  char const **pzDataType,    /* OUTPUT: Declared data type */
+  char const **pzCollSeq,     /* OUTPUT: Collation sequence name */
+  int *pNotNull,              /* OUTPUT: True if NOT NULL constraint exists */
+  int *pPrimaryKey,           /* OUTPUT: True if column part of PK */
+  int *pAutoinc               /* OUTPUT: True if column is auto-increment */
 );
 
 /*
@@ -7104,10 +7170,10 @@ SQLITE_API int sqlite3_table_column_metadata(
 ** See also the [load_extension() SQL function].
 */
 SQLITE_API int sqlite3_load_extension(
-    sqlite3 *db,       /* Load the extension into this database connection */
-    const char *zFile, /* Name of the shared library containing extension */
-    const char *zProc, /* Entry point.  Derived from zFile if 0 */
-    char **pzErrMsg    /* Put error message here if not 0 */
+  sqlite3 *db,          /* Load the extension into this database connection */
+  const char *zFile,    /* Name of the shared library containing extension */
+  const char *zProc,    /* Entry point.  Derived from zFile if 0 */
+  char **pzErrMsg       /* Put error message here if not 0 */
 );
 
 /*
@@ -7173,7 +7239,7 @@ SQLITE_API int sqlite3_enable_load_extension(sqlite3 *db, int onoff);
 ** See also: [sqlite3_reset_auto_extension()]
 ** and [sqlite3_cancel_auto_extension()]
 */
-SQLITE_API int sqlite3_auto_extension(void (*xEntryPoint)(void));
+SQLITE_API int sqlite3_auto_extension(void(*xEntryPoint)(void));
 
 /*
 ** CAPI3REF: Cancel Automatic Extension Loading
@@ -7185,7 +7251,7 @@ SQLITE_API int sqlite3_auto_extension(void (*xEntryPoint)(void));
 ** unregistered and it returns 0 if X was not on the list of initialization
 ** routines.
 */
-SQLITE_API int sqlite3_cancel_auto_extension(void (*xEntryPoint)(void));
+SQLITE_API int sqlite3_cancel_auto_extension(void(*xEntryPoint)(void));
 
 /*
 ** CAPI3REF: Reset Automatic Extension Loading
@@ -7221,29 +7287,30 @@ typedef struct sqlite3_module sqlite3_module;
 */
 struct sqlite3_module {
   int iVersion;
-  int (*xCreate)(sqlite3 *, void *pAux, int argc, const char *const *argv,
-                 sqlite3_vtab **ppVTab, char **);
-  int (*xConnect)(sqlite3 *, void *pAux, int argc, const char *const *argv,
-                  sqlite3_vtab **ppVTab, char **);
-  int (*xBestIndex)(sqlite3_vtab *pVTab, sqlite3_index_info *);
+  int (*xCreate)(sqlite3*, void *pAux,
+               int argc, const char *const*argv,
+               sqlite3_vtab **ppVTab, char**);
+  int (*xConnect)(sqlite3*, void *pAux,
+               int argc, const char *const*argv,
+               sqlite3_vtab **ppVTab, char**);
+  int (*xBestIndex)(sqlite3_vtab *pVTab, sqlite3_index_info*);
   int (*xDisconnect)(sqlite3_vtab *pVTab);
   int (*xDestroy)(sqlite3_vtab *pVTab);
   int (*xOpen)(sqlite3_vtab *pVTab, sqlite3_vtab_cursor **ppCursor);
-  int (*xClose)(sqlite3_vtab_cursor *);
-  int (*xFilter)(sqlite3_vtab_cursor *, int idxNum, const char *idxStr,
-                 int argc, sqlite3_value **argv);
-  int (*xNext)(sqlite3_vtab_cursor *);
-  int (*xEof)(sqlite3_vtab_cursor *);
-  int (*xColumn)(sqlite3_vtab_cursor *, sqlite3_context *, int);
-  int (*xRowid)(sqlite3_vtab_cursor *, sqlite3_int64 *pRowid);
+  int (*xClose)(sqlite3_vtab_cursor*);
+  int (*xFilter)(sqlite3_vtab_cursor*, int idxNum, const char *idxStr,
+                int argc, sqlite3_value **argv);
+  int (*xNext)(sqlite3_vtab_cursor*);
+  int (*xEof)(sqlite3_vtab_cursor*);
+  int (*xColumn)(sqlite3_vtab_cursor*, sqlite3_context*, int);
+  int (*xRowid)(sqlite3_vtab_cursor*, sqlite3_int64 *pRowid);
   int (*xUpdate)(sqlite3_vtab *, int, sqlite3_value **, sqlite3_int64 *);
   int (*xBegin)(sqlite3_vtab *pVTab);
   int (*xSync)(sqlite3_vtab *pVTab);
   int (*xCommit)(sqlite3_vtab *pVTab);
   int (*xRollback)(sqlite3_vtab *pVTab);
   int (*xFindFunction)(sqlite3_vtab *pVtab, int nArg, const char *zName,
-                       void (**pxFunc)(sqlite3_context *, int,
-                                       sqlite3_value **),
+                       void (**pxFunc)(sqlite3_context*,int,sqlite3_value**),
                        void **ppArg);
   int (*xRename)(sqlite3_vtab *pVtab, const char *zNew);
   /* The methods above are in version 1 of the sqlite_module object. Those
@@ -7253,7 +7320,7 @@ struct sqlite3_module {
   int (*xRollbackTo)(sqlite3_vtab *pVTab, int);
   /* The methods above are in versions 1 and 2 of the sqlite_module object.
   ** Those below are for version 3 and greater. */
-  int (*xShadowName)(const char *);
+  int (*xShadowName)(const char*);
   /* The methods above are in versions 1 through 3 of the sqlite_module object.
   ** Those below are for version 4 and greater. */
   int (*xIntegrity)(sqlite3_vtab *pVTab, const char *zSchema,
@@ -7364,34 +7431,34 @@ struct sqlite3_module {
 */
 struct sqlite3_index_info {
   /* Inputs */
-  int nConstraint; /* Number of entries in aConstraint */
+  int nConstraint;           /* Number of entries in aConstraint */
   struct sqlite3_index_constraint {
-    int iColumn;          /* Column constrained.  -1 for ROWID */
-    unsigned char op;     /* Constraint operator */
-    unsigned char usable; /* True if this constraint is usable */
-    int iTermOffset;      /* Used internally - xBestIndex should ignore */
-  } *aConstraint;         /* Table of WHERE clause constraints */
-  int nOrderBy;           /* Number of terms in the ORDER BY clause */
+     int iColumn;              /* Column constrained.  -1 for ROWID */
+     unsigned char op;         /* Constraint operator */
+     unsigned char usable;     /* True if this constraint is usable */
+     int iTermOffset;          /* Used internally - xBestIndex should ignore */
+  } *aConstraint;            /* Table of WHERE clause constraints */
+  int nOrderBy;              /* Number of terms in the ORDER BY clause */
   struct sqlite3_index_orderby {
-    int iColumn;        /* Column number */
-    unsigned char desc; /* True for DESC.  False for ASC. */
-  } *aOrderBy;          /* The ORDER BY clause */
+     int iColumn;              /* Column number */
+     unsigned char desc;       /* True for DESC.  False for ASC. */
+  } *aOrderBy;               /* The ORDER BY clause */
   /* Outputs */
   struct sqlite3_index_constraint_usage {
-    int argvIndex;      /* if >0, constraint is part of argv to xFilter */
-    unsigned char omit; /* Do not code a test for this constraint */
+    int argvIndex;           /* if >0, constraint is part of argv to xFilter */
+    unsigned char omit;      /* Do not code a test for this constraint */
   } *aConstraintUsage;
-  int idxNum;           /* Number used to identify the index */
-  char *idxStr;         /* String, possibly obtained from sqlite3_malloc */
-  int needToFreeIdxStr; /* Free idxStr using sqlite3_free() if true */
-  int orderByConsumed;  /* True if output is already ordered */
-  double estimatedCost; /* Estimated cost of using this index */
+  int idxNum;                /* Number used to identify the index */
+  char *idxStr;              /* String, possibly obtained from sqlite3_malloc */
+  int needToFreeIdxStr;      /* Free idxStr using sqlite3_free() if true */
+  int orderByConsumed;       /* True if output is already ordered */
+  double estimatedCost;           /* Estimated cost of using this index */
   /* Fields below are only available in SQLite 3.8.2 and later */
-  sqlite3_int64 estimatedRows; /* Estimated number of rows returned */
+  sqlite3_int64 estimatedRows;    /* Estimated number of rows returned */
   /* Fields below are only available in SQLite 3.9.0 and later */
-  int idxFlags; /* Mask of SQLITE_INDEX_SCAN_* flags */
+  int idxFlags;              /* Mask of SQLITE_INDEX_SCAN_* flags */
   /* Fields below are only available in SQLite 3.10.0 and later */
-  sqlite3_uint64 colUsed; /* Input: Mask of columns used by statement */
+  sqlite3_uint64 colUsed;    /* Input: Mask of columns used by statement */
 };
 
 /*
@@ -7401,7 +7468,7 @@ struct sqlite3_index_info {
 ** [sqlite3_index_info].idxFlags field to some combination of
 ** these bits.
 */
-#define SQLITE_INDEX_SCAN_UNIQUE 1 /* Scan visits at most 1 row */
+#define SQLITE_INDEX_SCAN_UNIQUE      1     /* Scan visits at most 1 row */
 
 /*
 ** CAPI3REF: Virtual Table Constraint Operator Codes
@@ -7441,23 +7508,23 @@ struct sqlite3_index_info {
 ** because the constraints are numeric) and so the sqlite3_vtab_collation()
 ** interface is not commonly needed.
 */
-#define SQLITE_INDEX_CONSTRAINT_EQ 2
-#define SQLITE_INDEX_CONSTRAINT_GT 4
-#define SQLITE_INDEX_CONSTRAINT_LE 8
-#define SQLITE_INDEX_CONSTRAINT_LT 16
-#define SQLITE_INDEX_CONSTRAINT_GE 32
-#define SQLITE_INDEX_CONSTRAINT_MATCH 64
-#define SQLITE_INDEX_CONSTRAINT_LIKE 65
-#define SQLITE_INDEX_CONSTRAINT_GLOB 66
-#define SQLITE_INDEX_CONSTRAINT_REGEXP 67
-#define SQLITE_INDEX_CONSTRAINT_NE 68
-#define SQLITE_INDEX_CONSTRAINT_ISNOT 69
-#define SQLITE_INDEX_CONSTRAINT_ISNOTNULL 70
-#define SQLITE_INDEX_CONSTRAINT_ISNULL 71
-#define SQLITE_INDEX_CONSTRAINT_IS 72
-#define SQLITE_INDEX_CONSTRAINT_LIMIT 73
-#define SQLITE_INDEX_CONSTRAINT_OFFSET 74
-#define SQLITE_INDEX_CONSTRAINT_FUNCTION 150
+#define SQLITE_INDEX_CONSTRAINT_EQ          2
+#define SQLITE_INDEX_CONSTRAINT_GT          4
+#define SQLITE_INDEX_CONSTRAINT_LE          8
+#define SQLITE_INDEX_CONSTRAINT_LT         16
+#define SQLITE_INDEX_CONSTRAINT_GE         32
+#define SQLITE_INDEX_CONSTRAINT_MATCH      64
+#define SQLITE_INDEX_CONSTRAINT_LIKE       65
+#define SQLITE_INDEX_CONSTRAINT_GLOB       66
+#define SQLITE_INDEX_CONSTRAINT_REGEXP     67
+#define SQLITE_INDEX_CONSTRAINT_NE         68
+#define SQLITE_INDEX_CONSTRAINT_ISNOT      69
+#define SQLITE_INDEX_CONSTRAINT_ISNOTNULL  70
+#define SQLITE_INDEX_CONSTRAINT_ISNULL     71
+#define SQLITE_INDEX_CONSTRAINT_IS         72
+#define SQLITE_INDEX_CONSTRAINT_LIMIT      73
+#define SQLITE_INDEX_CONSTRAINT_OFFSET     74
+#define SQLITE_INDEX_CONSTRAINT_FUNCTION  150
 
 /*
 ** CAPI3REF: Register A Virtual Table Implementation
@@ -7492,17 +7559,17 @@ struct sqlite3_index_info {
 ** See also: [sqlite3_drop_modules()]
 */
 SQLITE_API int sqlite3_create_module(
-    sqlite3 *db,             /* SQLite connection to register module with */
-    const char *zName,       /* Name of the module */
-    const sqlite3_module *p, /* Methods for the module */
-    void *pClientData        /* Client data for xCreate/xConnect */
+  sqlite3 *db,               /* SQLite connection to register module with */
+  const char *zName,         /* Name of the module */
+  const sqlite3_module *p,   /* Methods for the module */
+  void *pClientData          /* Client data for xCreate/xConnect */
 );
 SQLITE_API int sqlite3_create_module_v2(
-    sqlite3 *db,             /* SQLite connection to register module with */
-    const char *zName,       /* Name of the module */
-    const sqlite3_module *p, /* Methods for the module */
-    void *pClientData,       /* Client data for xCreate/xConnect */
-    void (*xDestroy)(void *) /* Module destructor function */
+  sqlite3 *db,               /* SQLite connection to register module with */
+  const char *zName,         /* Name of the module */
+  const sqlite3_module *p,   /* Methods for the module */
+  void *pClientData,         /* Client data for xCreate/xConnect */
+  void(*xDestroy)(void*)     /* Module destructor function */
 );
 
 /*
@@ -7518,8 +7585,8 @@ SQLITE_API int sqlite3_create_module_v2(
 ** See also: [sqlite3_create_module()]
 */
 SQLITE_API int sqlite3_drop_modules(
-    sqlite3 *db,        /* Remove modules from this connection */
-    const char **azKeep /* Except, do not remove the ones named here */
+  sqlite3 *db,                /* Remove modules from this connection */
+  const char **azKeep         /* Except, do not remove the ones named here */
 );
 
 /*
@@ -7541,9 +7608,9 @@ SQLITE_API int sqlite3_drop_modules(
 ** freed by sqlite3_free() and the zErrMsg field will be zeroed.
 */
 struct sqlite3_vtab {
-  const sqlite3_module *pModule; /* The module for this virtual table */
-  int nRef;                      /* Number of open cursors */
-  char *zErrMsg;                 /* Error message from sqlite3_mprintf() */
+  const sqlite3_module *pModule;  /* The module for this virtual table */
+  int nRef;                       /* Number of open cursors */
+  char *zErrMsg;                  /* Error message from sqlite3_mprintf() */
   /* Virtual table implementations will typically add additional fields */
 };
 
@@ -7565,7 +7632,7 @@ struct sqlite3_vtab {
 ** are common to all implementations.
 */
 struct sqlite3_vtab_cursor {
-  sqlite3_vtab *pVtab; /* Virtual table of this cursor */
+  sqlite3_vtab *pVtab;      /* Virtual table of this cursor */
   /* Virtual table implementations will typically add additional fields */
 };
 
@@ -7577,7 +7644,7 @@ struct sqlite3_vtab_cursor {
 ** to declare the format (the names and datatypes of the columns) of
 ** the virtual tables they implement.
 */
-SQLITE_API int sqlite3_declare_vtab(sqlite3 *, const char *zSQL);
+SQLITE_API int sqlite3_declare_vtab(sqlite3*, const char *zSQL);
 
 /*
 ** CAPI3REF: Overload A Function For A Virtual Table
@@ -7596,8 +7663,7 @@ SQLITE_API int sqlite3_declare_vtab(sqlite3 *, const char *zSQL);
 ** purpose is to be a placeholder function that can be overloaded
 ** by a [virtual table].
 */
-SQLITE_API int sqlite3_overload_function(sqlite3 *, const char *zFuncName,
-                                         int nArg);
+SQLITE_API int sqlite3_overload_function(sqlite3*, const char *zFuncName, int nArg);
 
 /*
 ** CAPI3REF: A Handle To An Open BLOB
@@ -7696,9 +7762,15 @@ typedef struct sqlite3_blob sqlite3_blob;
 ** [sqlite3_blob_reopen()], [sqlite3_blob_read()],
 ** [sqlite3_blob_bytes()], [sqlite3_blob_write()].
 */
-SQLITE_API int sqlite3_blob_open(sqlite3 *, const char *zDb, const char *zTable,
-                                 const char *zColumn, sqlite3_int64 iRow,
-                                 int flags, sqlite3_blob **ppBlob);
+SQLITE_API int sqlite3_blob_open(
+  sqlite3*,
+  const char *zDb,
+  const char *zTable,
+  const char *zColumn,
+  sqlite3_int64 iRow,
+  int flags,
+  sqlite3_blob **ppBlob
+);
 
 /*
 ** CAPI3REF: Move a BLOB Handle to a New Row
@@ -7833,8 +7905,7 @@ SQLITE_API int sqlite3_blob_read(sqlite3_blob *, void *Z, int N, int iOffset);
 **
 ** See also: [sqlite3_blob_read()].
 */
-SQLITE_API int sqlite3_blob_write(sqlite3_blob *, const void *z, int n,
-                                  int iOffset);
+SQLITE_API int sqlite3_blob_write(sqlite3_blob *, const void *z, int n, int iOffset);
 
 /*
 ** CAPI3REF: Virtual File System Objects
@@ -7866,8 +7937,8 @@ SQLITE_API int sqlite3_blob_write(sqlite3_blob *, const void *z, int n,
 ** the default.  The choice for the new VFS is arbitrary.)^
 */
 SQLITE_API sqlite3_vfs *sqlite3_vfs_find(const char *zVfsName);
-SQLITE_API int sqlite3_vfs_register(sqlite3_vfs *, int makeDflt);
-SQLITE_API int sqlite3_vfs_unregister(sqlite3_vfs *);
+SQLITE_API int sqlite3_vfs_register(sqlite3_vfs*, int makeDflt);
+SQLITE_API int sqlite3_vfs_unregister(sqlite3_vfs*);
 
 /*
 ** CAPI3REF: Mutexes
@@ -7968,9 +8039,11 @@ SQLITE_API int sqlite3_vfs_unregister(sqlite3_vfs *);
 **
 ** ^(Some systems (for example, Windows 95) do not support the operation
 ** implemented by sqlite3_mutex_try().  On those systems, sqlite3_mutex_try()
-** will always return SQLITE_BUSY. The SQLite core only ever uses
-** sqlite3_mutex_try() as an optimization so this is acceptable
-** behavior.)^
+** will always return SQLITE_BUSY. In most cases the SQLite core only uses
+** sqlite3_mutex_try() as an optimization, so this is acceptable
+** behavior. The exceptions are unix builds that set the
+** SQLITE_ENABLE_SETLK_TIMEOUT build option. In that case a working
+** sqlite3_mutex_try() is required.)^
 **
 ** ^The sqlite3_mutex_leave() routine exits a mutex that was
 ** previously entered by the same thread.   The behavior
@@ -7984,10 +8057,10 @@ SQLITE_API int sqlite3_vfs_unregister(sqlite3_vfs *);
 ** See also: [sqlite3_mutex_held()] and [sqlite3_mutex_notheld()].
 */
 SQLITE_API sqlite3_mutex *sqlite3_mutex_alloc(int);
-SQLITE_API void sqlite3_mutex_free(sqlite3_mutex *);
-SQLITE_API void sqlite3_mutex_enter(sqlite3_mutex *);
-SQLITE_API int sqlite3_mutex_try(sqlite3_mutex *);
-SQLITE_API void sqlite3_mutex_leave(sqlite3_mutex *);
+SQLITE_API void sqlite3_mutex_free(sqlite3_mutex*);
+SQLITE_API void sqlite3_mutex_enter(sqlite3_mutex*);
+SQLITE_API int sqlite3_mutex_try(sqlite3_mutex*);
+SQLITE_API void sqlite3_mutex_leave(sqlite3_mutex*);
 
 /*
 ** CAPI3REF: Mutex Methods Object
@@ -8097,8 +8170,8 @@ struct sqlite3_mutex_methods {
 ** interface should also return 1 when given a NULL pointer.
 */
 #ifndef NDEBUG
-SQLITE_API int sqlite3_mutex_held(sqlite3_mutex *);
-SQLITE_API int sqlite3_mutex_notheld(sqlite3_mutex *);
+SQLITE_API int sqlite3_mutex_held(sqlite3_mutex*);
+SQLITE_API int sqlite3_mutex_notheld(sqlite3_mutex*);
 #endif
 
 /*
@@ -8111,25 +8184,26 @@ SQLITE_API int sqlite3_mutex_notheld(sqlite3_mutex *);
 ** next.  Applications that override the built-in mutex logic must be
 ** prepared to accommodate additional static mutexes.
 */
-#define SQLITE_MUTEX_FAST 0
-#define SQLITE_MUTEX_RECURSIVE 1
-#define SQLITE_MUTEX_STATIC_MAIN 2
-#define SQLITE_MUTEX_STATIC_MEM 3   /* sqlite3_malloc() */
-#define SQLITE_MUTEX_STATIC_MEM2 4  /* NOT USED */
-#define SQLITE_MUTEX_STATIC_OPEN 4  /* sqlite3BtreeOpen() */
-#define SQLITE_MUTEX_STATIC_PRNG 5  /* sqlite3_randomness() */
-#define SQLITE_MUTEX_STATIC_LRU 6   /* lru page list */
-#define SQLITE_MUTEX_STATIC_LRU2 7  /* NOT USED */
-#define SQLITE_MUTEX_STATIC_PMEM 7  /* sqlite3PageMalloc() */
-#define SQLITE_MUTEX_STATIC_APP1 8  /* For use by application */
-#define SQLITE_MUTEX_STATIC_APP2 9  /* For use by application */
-#define SQLITE_MUTEX_STATIC_APP3 10 /* For use by application */
-#define SQLITE_MUTEX_STATIC_VFS1 11 /* For use by built-in VFS */
-#define SQLITE_MUTEX_STATIC_VFS2 12 /* For use by extension VFS */
-#define SQLITE_MUTEX_STATIC_VFS3 13 /* For use by application VFS */
+#define SQLITE_MUTEX_FAST             0
+#define SQLITE_MUTEX_RECURSIVE        1
+#define SQLITE_MUTEX_STATIC_MAIN      2
+#define SQLITE_MUTEX_STATIC_MEM       3  /* sqlite3_malloc() */
+#define SQLITE_MUTEX_STATIC_MEM2      4  /* NOT USED */
+#define SQLITE_MUTEX_STATIC_OPEN      4  /* sqlite3BtreeOpen() */
+#define SQLITE_MUTEX_STATIC_PRNG      5  /* sqlite3_randomness() */
+#define SQLITE_MUTEX_STATIC_LRU       6  /* lru page list */
+#define SQLITE_MUTEX_STATIC_LRU2      7  /* NOT USED */
+#define SQLITE_MUTEX_STATIC_PMEM      7  /* sqlite3PageMalloc() */
+#define SQLITE_MUTEX_STATIC_APP1      8  /* For use by application */
+#define SQLITE_MUTEX_STATIC_APP2      9  /* For use by application */
+#define SQLITE_MUTEX_STATIC_APP3     10  /* For use by application */
+#define SQLITE_MUTEX_STATIC_VFS1     11  /* For use by built-in VFS */
+#define SQLITE_MUTEX_STATIC_VFS2     12  /* For use by extension VFS */
+#define SQLITE_MUTEX_STATIC_VFS3     13  /* For use by application VFS */
 
 /* Legacy compatibility: */
-#define SQLITE_MUTEX_STATIC_MASTER 2
+#define SQLITE_MUTEX_STATIC_MASTER    2
+
 
 /*
 ** CAPI3REF: Retrieve the mutex for a database connection
@@ -8141,7 +8215,7 @@ SQLITE_API int sqlite3_mutex_notheld(sqlite3_mutex *);
 ** ^If the [threading mode] is Single-thread or Multi-thread then this
 ** routine returns a NULL pointer.
 */
-SQLITE_API sqlite3_mutex *sqlite3_db_mutex(sqlite3 *);
+SQLITE_API sqlite3_mutex *sqlite3_db_mutex(sqlite3*);
 
 /*
 ** CAPI3REF: Low-Level Control Of Database Files
@@ -8184,8 +8258,7 @@ SQLITE_API sqlite3_mutex *sqlite3_db_mutex(sqlite3 *);
 **
 ** See also: [file control opcodes]
 */
-SQLITE_API int sqlite3_file_control(sqlite3 *, const char *zDbName, int op,
-                                    void *);
+SQLITE_API int sqlite3_file_control(sqlite3*, const char *zDbName, int op, void*);
 
 /*
 ** CAPI3REF: Testing Interface
@@ -8217,41 +8290,42 @@ SQLITE_API int sqlite3_test_control(int op, ...);
 ** Applications should not use any of these parameters or the
 ** [sqlite3_test_control()] interface.
 */
-#define SQLITE_TESTCTRL_FIRST 5
-#define SQLITE_TESTCTRL_PRNG_SAVE 5
-#define SQLITE_TESTCTRL_PRNG_RESTORE 6
-#define SQLITE_TESTCTRL_PRNG_RESET 7 /* NOT USED */
-#define SQLITE_TESTCTRL_FK_NO_ACTION 7
-#define SQLITE_TESTCTRL_BITVEC_TEST 8
-#define SQLITE_TESTCTRL_FAULT_INSTALL 9
-#define SQLITE_TESTCTRL_BENIGN_MALLOC_HOOKS 10
-#define SQLITE_TESTCTRL_PENDING_BYTE 11
-#define SQLITE_TESTCTRL_ASSERT 12
-#define SQLITE_TESTCTRL_ALWAYS 13
-#define SQLITE_TESTCTRL_RESERVE 14 /* NOT USED */
-#define SQLITE_TESTCTRL_OPTIMIZATIONS 15
-#define SQLITE_TESTCTRL_ISKEYWORD 16     /* NOT USED */
-#define SQLITE_TESTCTRL_SCRATCHMALLOC 17 /* NOT USED */
-#define SQLITE_TESTCTRL_INTERNAL_FUNCTIONS 17
-#define SQLITE_TESTCTRL_LOCALTIME_FAULT 18
-#define SQLITE_TESTCTRL_EXPLAIN_STMT 19 /* NOT USED */
-#define SQLITE_TESTCTRL_ONCE_RESET_THRESHOLD 19
-#define SQLITE_TESTCTRL_NEVER_CORRUPT 20
-#define SQLITE_TESTCTRL_VDBE_COVERAGE 21
-#define SQLITE_TESTCTRL_BYTEORDER 22
-#define SQLITE_TESTCTRL_ISINIT 23
-#define SQLITE_TESTCTRL_SORTER_MMAP 24
-#define SQLITE_TESTCTRL_IMPOSTER 25
-#define SQLITE_TESTCTRL_PARSER_COVERAGE 26
-#define SQLITE_TESTCTRL_RESULT_INTREAL 27
-#define SQLITE_TESTCTRL_PRNG_SEED 28
-#define SQLITE_TESTCTRL_EXTRA_SCHEMA_CHECKS 29
-#define SQLITE_TESTCTRL_SEEK_COUNT 30
-#define SQLITE_TESTCTRL_TRACEFLAGS 31
-#define SQLITE_TESTCTRL_TUNE 32
-#define SQLITE_TESTCTRL_LOGEST 33
-#define SQLITE_TESTCTRL_USELONGDOUBLE 34
-#define SQLITE_TESTCTRL_LAST 34 /* Largest TESTCTRL */
+#define SQLITE_TESTCTRL_FIRST                    5
+#define SQLITE_TESTCTRL_PRNG_SAVE                5
+#define SQLITE_TESTCTRL_PRNG_RESTORE             6
+#define SQLITE_TESTCTRL_PRNG_RESET               7  /* NOT USED */
+#define SQLITE_TESTCTRL_FK_NO_ACTION             7
+#define SQLITE_TESTCTRL_BITVEC_TEST              8
+#define SQLITE_TESTCTRL_FAULT_INSTALL            9
+#define SQLITE_TESTCTRL_BENIGN_MALLOC_HOOKS     10
+#define SQLITE_TESTCTRL_PENDING_BYTE            11
+#define SQLITE_TESTCTRL_ASSERT                  12
+#define SQLITE_TESTCTRL_ALWAYS                  13
+#define SQLITE_TESTCTRL_RESERVE                 14  /* NOT USED */
+#define SQLITE_TESTCTRL_JSON_SELFCHECK          14
+#define SQLITE_TESTCTRL_OPTIMIZATIONS           15
+#define SQLITE_TESTCTRL_ISKEYWORD               16  /* NOT USED */
+#define SQLITE_TESTCTRL_SCRATCHMALLOC           17  /* NOT USED */
+#define SQLITE_TESTCTRL_INTERNAL_FUNCTIONS      17
+#define SQLITE_TESTCTRL_LOCALTIME_FAULT         18
+#define SQLITE_TESTCTRL_EXPLAIN_STMT            19  /* NOT USED */
+#define SQLITE_TESTCTRL_ONCE_RESET_THRESHOLD    19
+#define SQLITE_TESTCTRL_NEVER_CORRUPT           20
+#define SQLITE_TESTCTRL_VDBE_COVERAGE           21
+#define SQLITE_TESTCTRL_BYTEORDER               22
+#define SQLITE_TESTCTRL_ISINIT                  23
+#define SQLITE_TESTCTRL_SORTER_MMAP             24
+#define SQLITE_TESTCTRL_IMPOSTER                25
+#define SQLITE_TESTCTRL_PARSER_COVERAGE         26
+#define SQLITE_TESTCTRL_RESULT_INTREAL          27
+#define SQLITE_TESTCTRL_PRNG_SEED               28
+#define SQLITE_TESTCTRL_EXTRA_SCHEMA_CHECKS     29
+#define SQLITE_TESTCTRL_SEEK_COUNT              30
+#define SQLITE_TESTCTRL_TRACEFLAGS              31
+#define SQLITE_TESTCTRL_TUNE                    32
+#define SQLITE_TESTCTRL_LOGEST                  33
+#define SQLITE_TESTCTRL_USELONGDOUBLE           34
+#define SQLITE_TESTCTRL_LAST                    34  /* Largest TESTCTRL */
 
 /*
 ** CAPI3REF: SQL Keyword Checking
@@ -8301,8 +8375,8 @@ SQLITE_API int sqlite3_test_control(int op, ...);
 ** new keywords may be added to future releases of SQLite.
 */
 SQLITE_API int sqlite3_keyword_count(void);
-SQLITE_API int sqlite3_keyword_name(int, const char **, int *);
-SQLITE_API int sqlite3_keyword_check(const char *, int);
+SQLITE_API int sqlite3_keyword_name(int,const char**,int*);
+SQLITE_API int sqlite3_keyword_check(const char*,int);
 
 /*
 ** CAPI3REF: Dynamic String Object
@@ -8347,7 +8421,7 @@ typedef struct sqlite3_str sqlite3_str;
 ** the value set for [sqlite3_limit](D,[SQLITE_LIMIT_LENGTH]) instead
 ** of [SQLITE_MAX_LENGTH].
 */
-SQLITE_API sqlite3_str *sqlite3_str_new(sqlite3 *);
+SQLITE_API sqlite3_str *sqlite3_str_new(sqlite3*);
 
 /*
 ** CAPI3REF: Finalize A Dynamic String
@@ -8362,7 +8436,7 @@ SQLITE_API sqlite3_str *sqlite3_str_new(sqlite3 *);
 ** [sqlite3_str_finish(X)] interface will also return a NULL pointer if the
 ** string in [sqlite3_str] object X is zero bytes long.
 */
-SQLITE_API char *sqlite3_str_finish(sqlite3_str *);
+SQLITE_API char *sqlite3_str_finish(sqlite3_str*);
 
 /*
 ** CAPI3REF: Add Content To A Dynamic String
@@ -8396,13 +8470,12 @@ SQLITE_API char *sqlite3_str_finish(sqlite3_str *);
 ** is recorded in the [sqlite3_str] object and can be recovered by a
 ** subsequent call to [sqlite3_str_errcode(X)].
 */
-SQLITE_API void sqlite3_str_appendf(sqlite3_str *, const char *zFormat, ...);
-SQLITE_API void sqlite3_str_vappendf(sqlite3_str *, const char *zFormat,
-                                     va_list);
-SQLITE_API void sqlite3_str_append(sqlite3_str *, const char *zIn, int N);
-SQLITE_API void sqlite3_str_appendall(sqlite3_str *, const char *zIn);
-SQLITE_API void sqlite3_str_appendchar(sqlite3_str *, int N, char C);
-SQLITE_API void sqlite3_str_reset(sqlite3_str *);
+SQLITE_API void sqlite3_str_appendf(sqlite3_str*, const char *zFormat, ...);
+SQLITE_API void sqlite3_str_vappendf(sqlite3_str*, const char *zFormat, va_list);
+SQLITE_API void sqlite3_str_append(sqlite3_str*, const char *zIn, int N);
+SQLITE_API void sqlite3_str_appendall(sqlite3_str*, const char *zIn);
+SQLITE_API void sqlite3_str_appendchar(sqlite3_str*, int N, char C);
+SQLITE_API void sqlite3_str_reset(sqlite3_str*);
 
 /*
 ** CAPI3REF: Status Of A Dynamic String
@@ -8433,9 +8506,9 @@ SQLITE_API void sqlite3_str_reset(sqlite3_str *);
 ** outside the range of 0 to [sqlite3_str_length(X)] and do not read or
 ** write any byte after any subsequent sqlite3_str method call.
 */
-SQLITE_API int sqlite3_str_errcode(sqlite3_str *);
-SQLITE_API int sqlite3_str_length(sqlite3_str *);
-SQLITE_API char *sqlite3_str_value(sqlite3_str *);
+SQLITE_API int sqlite3_str_errcode(sqlite3_str*);
+SQLITE_API int sqlite3_str_length(sqlite3_str*);
+SQLITE_API char *sqlite3_str_value(sqlite3_str*);
 
 /*
 ** CAPI3REF: SQLite Runtime Status
@@ -8463,10 +8536,14 @@ SQLITE_API char *sqlite3_str_value(sqlite3_str *);
 **
 ** See also: [sqlite3_db_status()]
 */
-SQLITE_API int sqlite3_status(int op, int *pCurrent, int *pHighwater,
-                              int resetFlag);
-SQLITE_API int sqlite3_status64(int op, sqlite3_int64 *pCurrent,
-                                sqlite3_int64 *pHighwater, int resetFlag);
+SQLITE_API int sqlite3_status(int op, int *pCurrent, int *pHighwater, int resetFlag);
+SQLITE_API int sqlite3_status64(
+  int op,
+  sqlite3_int64 *pCurrent,
+  sqlite3_int64 *pHighwater,
+  int resetFlag
+);
+
 
 /*
 ** CAPI3REF: Status Parameters
@@ -8535,16 +8612,16 @@ SQLITE_API int sqlite3_status64(int op, sqlite3_int64 *pCurrent,
 **
 ** New status parameters may be added from time to time.
 */
-#define SQLITE_STATUS_MEMORY_USED 0
-#define SQLITE_STATUS_PAGECACHE_USED 1
-#define SQLITE_STATUS_PAGECACHE_OVERFLOW 2
-#define SQLITE_STATUS_SCRATCH_USED 3     /* NOT USED */
-#define SQLITE_STATUS_SCRATCH_OVERFLOW 4 /* NOT USED */
-#define SQLITE_STATUS_MALLOC_SIZE 5
-#define SQLITE_STATUS_PARSER_STACK 6
-#define SQLITE_STATUS_PAGECACHE_SIZE 7
-#define SQLITE_STATUS_SCRATCH_SIZE 8 /* NOT USED */
-#define SQLITE_STATUS_MALLOC_COUNT 9
+#define SQLITE_STATUS_MEMORY_USED          0
+#define SQLITE_STATUS_PAGECACHE_USED       1
+#define SQLITE_STATUS_PAGECACHE_OVERFLOW   2
+#define SQLITE_STATUS_SCRATCH_USED         3  /* NOT USED */
+#define SQLITE_STATUS_SCRATCH_OVERFLOW     4  /* NOT USED */
+#define SQLITE_STATUS_MALLOC_SIZE          5
+#define SQLITE_STATUS_PARSER_STACK         6
+#define SQLITE_STATUS_PAGECACHE_SIZE       7
+#define SQLITE_STATUS_SCRATCH_SIZE         8  /* NOT USED */
+#define SQLITE_STATUS_MALLOC_COUNT         9
 
 /*
 ** CAPI3REF: Database Connection Status
@@ -8569,8 +8646,7 @@ SQLITE_API int sqlite3_status64(int op, sqlite3_int64 *pCurrent,
 **
 ** See also: [sqlite3_status()] and [sqlite3_stmt_status()].
 */
-SQLITE_API int sqlite3_db_status(sqlite3 *, int op, int *pCur, int *pHiwtr,
-                                 int resetFlg);
+SQLITE_API int sqlite3_db_status(sqlite3*, int op, int *pCur, int *pHiwtr, int resetFlg);
 
 /*
 ** CAPI3REF: Status Parameters for database connections
@@ -8683,20 +8759,21 @@ SQLITE_API int sqlite3_db_status(sqlite3 *, int op, int *pCur, int *pHiwtr,
 ** </dd>
 ** </dl>
 */
-#define SQLITE_DBSTATUS_LOOKASIDE_USED 0
-#define SQLITE_DBSTATUS_CACHE_USED 1
-#define SQLITE_DBSTATUS_SCHEMA_USED 2
-#define SQLITE_DBSTATUS_STMT_USED 3
-#define SQLITE_DBSTATUS_LOOKASIDE_HIT 4
-#define SQLITE_DBSTATUS_LOOKASIDE_MISS_SIZE 5
-#define SQLITE_DBSTATUS_LOOKASIDE_MISS_FULL 6
-#define SQLITE_DBSTATUS_CACHE_HIT 7
-#define SQLITE_DBSTATUS_CACHE_MISS 8
-#define SQLITE_DBSTATUS_CACHE_WRITE 9
-#define SQLITE_DBSTATUS_DEFERRED_FKS 10
-#define SQLITE_DBSTATUS_CACHE_USED_SHARED 11
-#define SQLITE_DBSTATUS_CACHE_SPILL 12
-#define SQLITE_DBSTATUS_MAX 12 /* Largest defined DBSTATUS */
+#define SQLITE_DBSTATUS_LOOKASIDE_USED       0
+#define SQLITE_DBSTATUS_CACHE_USED           1
+#define SQLITE_DBSTATUS_SCHEMA_USED          2
+#define SQLITE_DBSTATUS_STMT_USED            3
+#define SQLITE_DBSTATUS_LOOKASIDE_HIT        4
+#define SQLITE_DBSTATUS_LOOKASIDE_MISS_SIZE  5
+#define SQLITE_DBSTATUS_LOOKASIDE_MISS_FULL  6
+#define SQLITE_DBSTATUS_CACHE_HIT            7
+#define SQLITE_DBSTATUS_CACHE_MISS           8
+#define SQLITE_DBSTATUS_CACHE_WRITE          9
+#define SQLITE_DBSTATUS_DEFERRED_FKS        10
+#define SQLITE_DBSTATUS_CACHE_USED_SHARED   11
+#define SQLITE_DBSTATUS_CACHE_SPILL         12
+#define SQLITE_DBSTATUS_MAX                 12   /* Largest defined DBSTATUS */
+
 
 /*
 ** CAPI3REF: Prepared Statement Status
@@ -8722,7 +8799,7 @@ SQLITE_API int sqlite3_db_status(sqlite3 *, int op, int *pCur, int *pHiwtr,
 **
 ** See also: [sqlite3_status()] and [sqlite3_db_status()].
 */
-SQLITE_API int sqlite3_stmt_status(sqlite3_stmt *, int op, int resetFlg);
+SQLITE_API int sqlite3_stmt_status(sqlite3_stmt*, int op,int resetFlg);
 
 /*
 ** CAPI3REF: Status Parameters for prepared statements
@@ -8789,15 +8866,15 @@ SQLITE_API int sqlite3_stmt_status(sqlite3_stmt *, int op, int resetFlg);
 ** </dd>
 ** </dl>
 */
-#define SQLITE_STMTSTATUS_FULLSCAN_STEP 1
-#define SQLITE_STMTSTATUS_SORT 2
-#define SQLITE_STMTSTATUS_AUTOINDEX 3
-#define SQLITE_STMTSTATUS_VM_STEP 4
-#define SQLITE_STMTSTATUS_REPREPARE 5
-#define SQLITE_STMTSTATUS_RUN 6
-#define SQLITE_STMTSTATUS_FILTER_MISS 7
-#define SQLITE_STMTSTATUS_FILTER_HIT 8
-#define SQLITE_STMTSTATUS_MEMUSED 99
+#define SQLITE_STMTSTATUS_FULLSCAN_STEP     1
+#define SQLITE_STMTSTATUS_SORT              2
+#define SQLITE_STMTSTATUS_AUTOINDEX         3
+#define SQLITE_STMTSTATUS_VM_STEP           4
+#define SQLITE_STMTSTATUS_REPREPARE         5
+#define SQLITE_STMTSTATUS_RUN               6
+#define SQLITE_STMTSTATUS_FILTER_MISS       7
+#define SQLITE_STMTSTATUS_FILTER_HIT        8
+#define SQLITE_STMTSTATUS_MEMUSED           99
 
 /*
 ** CAPI3REF: Custom Page Cache Object
@@ -8824,8 +8901,8 @@ typedef struct sqlite3_pcache sqlite3_pcache;
 */
 typedef struct sqlite3_pcache_page sqlite3_pcache_page;
 struct sqlite3_pcache_page {
-  void *pBuf;   /* The content of the page */
-  void *pExtra; /* Extra information associated with the page */
+  void *pBuf;        /* The content of the page */
+  void *pExtra;      /* Extra information associated with the page */
 };
 
 /*
@@ -8991,19 +9068,18 @@ typedef struct sqlite3_pcache_methods2 sqlite3_pcache_methods2;
 struct sqlite3_pcache_methods2 {
   int iVersion;
   void *pArg;
-  int (*xInit)(void *);
-  void (*xShutdown)(void *);
+  int (*xInit)(void*);
+  void (*xShutdown)(void*);
   sqlite3_pcache *(*xCreate)(int szPage, int szExtra, int bPurgeable);
-  void (*xCachesize)(sqlite3_pcache *, int nCachesize);
-  int (*xPagecount)(sqlite3_pcache *);
-  sqlite3_pcache_page *(*xFetch)(sqlite3_pcache *, unsigned key,
-                                 int createFlag);
-  void (*xUnpin)(sqlite3_pcache *, sqlite3_pcache_page *, int discard);
-  void (*xRekey)(sqlite3_pcache *, sqlite3_pcache_page *, unsigned oldKey,
-                 unsigned newKey);
-  void (*xTruncate)(sqlite3_pcache *, unsigned iLimit);
-  void (*xDestroy)(sqlite3_pcache *);
-  void (*xShrink)(sqlite3_pcache *);
+  void (*xCachesize)(sqlite3_pcache*, int nCachesize);
+  int (*xPagecount)(sqlite3_pcache*);
+  sqlite3_pcache_page *(*xFetch)(sqlite3_pcache*, unsigned key, int createFlag);
+  void (*xUnpin)(sqlite3_pcache*, sqlite3_pcache_page*, int discard);
+  void (*xRekey)(sqlite3_pcache*, sqlite3_pcache_page*,
+      unsigned oldKey, unsigned newKey);
+  void (*xTruncate)(sqlite3_pcache*, unsigned iLimit);
+  void (*xDestroy)(sqlite3_pcache*);
+  void (*xShrink)(sqlite3_pcache*);
 };
 
 /*
@@ -9014,17 +9090,18 @@ struct sqlite3_pcache_methods2 {
 typedef struct sqlite3_pcache_methods sqlite3_pcache_methods;
 struct sqlite3_pcache_methods {
   void *pArg;
-  int (*xInit)(void *);
-  void (*xShutdown)(void *);
+  int (*xInit)(void*);
+  void (*xShutdown)(void*);
   sqlite3_pcache *(*xCreate)(int szPage, int bPurgeable);
-  void (*xCachesize)(sqlite3_pcache *, int nCachesize);
-  int (*xPagecount)(sqlite3_pcache *);
-  void *(*xFetch)(sqlite3_pcache *, unsigned key, int createFlag);
-  void (*xUnpin)(sqlite3_pcache *, void *, int discard);
-  void (*xRekey)(sqlite3_pcache *, void *, unsigned oldKey, unsigned newKey);
-  void (*xTruncate)(sqlite3_pcache *, unsigned iLimit);
-  void (*xDestroy)(sqlite3_pcache *);
+  void (*xCachesize)(sqlite3_pcache*, int nCachesize);
+  int (*xPagecount)(sqlite3_pcache*);
+  void *(*xFetch)(sqlite3_pcache*, unsigned key, int createFlag);
+  void (*xUnpin)(sqlite3_pcache*, void*, int discard);
+  void (*xRekey)(sqlite3_pcache*, void*, unsigned oldKey, unsigned newKey);
+  void (*xTruncate)(sqlite3_pcache*, unsigned iLimit);
+  void (*xDestroy)(sqlite3_pcache*);
 };
+
 
 /*
 ** CAPI3REF: Online Backup Object
@@ -9224,11 +9301,11 @@ typedef struct sqlite3_backup sqlite3_backup;
 ** same time as another thread is invoking sqlite3_backup_step() it is
 ** possible that they return invalid values.
 */
-SQLITE_API sqlite3_backup *
-sqlite3_backup_init(sqlite3 *pDest,         /* Destination database handle */
-                    const char *zDestName,  /* Destination database name */
-                    sqlite3 *pSource,       /* Source database handle */
-                    const char *zSourceName /* Source database name */
+SQLITE_API sqlite3_backup *sqlite3_backup_init(
+  sqlite3 *pDest,                        /* Destination database handle */
+  const char *zDestName,                 /* Destination database name */
+  sqlite3 *pSource,                      /* Source database handle */
+  const char *zSourceName                /* Source database name */
 );
 SQLITE_API int sqlite3_backup_step(sqlite3_backup *p, int nPage);
 SQLITE_API int sqlite3_backup_finish(sqlite3_backup *p);
@@ -9351,10 +9428,11 @@ SQLITE_API int sqlite3_backup_pagecount(sqlite3_backup *p);
 ** SQLITE_LOCKED.)^
 */
 SQLITE_API int sqlite3_unlock_notify(
-    sqlite3 *pBlocked,                       /* Waiting connection */
-    void (*xNotify)(void **apArg, int nArg), /* Callback function to invoke */
-    void *pNotifyArg                         /* Argument to pass to xNotify */
+  sqlite3 *pBlocked,                          /* Waiting connection */
+  void (*xNotify)(void **apArg, int nArg),    /* Callback function to invoke */
+  void *pNotifyArg                            /* Argument to pass to xNotify */
 );
+
 
 /*
 ** CAPI3REF: String Comparison
@@ -9405,8 +9483,7 @@ SQLITE_API int sqlite3_strglob(const char *zGlob, const char *zStr);
 **
 ** See also: [sqlite3_strglob()].
 */
-SQLITE_API int sqlite3_strlike(const char *zGlob, const char *zStr,
-                               unsigned int cEsc);
+SQLITE_API int sqlite3_strlike(const char *zGlob, const char *zStr, unsigned int cEsc);
 
 /*
 ** CAPI3REF: Error Logging Interface
@@ -9466,9 +9543,11 @@ SQLITE_API void sqlite3_log(int iErrCode, const char *zFormat, ...);
 ** [wal_autocheckpoint pragma] both invoke [sqlite3_wal_hook()] and will
 ** overwrite any prior [sqlite3_wal_hook()] settings.
 */
-SQLITE_API void *sqlite3_wal_hook(sqlite3 *,
-                                  int (*)(void *, sqlite3 *, const char *, int),
-                                  void *);
+SQLITE_API void *sqlite3_wal_hook(
+  sqlite3*,
+  int(*)(void *,sqlite3*,const char*,int),
+  void*
+);
 
 /*
 ** CAPI3REF: Configure an auto-checkpoint
@@ -9616,11 +9695,11 @@ SQLITE_API int sqlite3_wal_checkpoint(sqlite3 *db, const char *zDb);
 ** from SQL.
 */
 SQLITE_API int sqlite3_wal_checkpoint_v2(
-    sqlite3 *db,     /* Database handle */
-    const char *zDb, /* Name of attached database (or NULL) */
-    int eMode,       /* SQLITE_CHECKPOINT_* value */
-    int *pnLog,      /* OUT: Size of WAL log in frames */
-    int *pnCkpt      /* OUT: Total number of frames checkpointed */
+  sqlite3 *db,                    /* Database handle */
+  const char *zDb,                /* Name of attached database (or NULL) */
+  int eMode,                      /* SQLITE_CHECKPOINT_* value */
+  int *pnLog,                     /* OUT: Size of WAL log in frames */
+  int *pnCkpt                     /* OUT: Total number of frames checkpointed */
 );
 
 /*
@@ -9632,10 +9711,10 @@ SQLITE_API int sqlite3_wal_checkpoint_v2(
 ** See the [sqlite3_wal_checkpoint_v2()] documentation for details on the
 ** meaning of each of these checkpoint modes.
 */
-#define SQLITE_CHECKPOINT_PASSIVE 0  /* Do as much as possible w/o blocking */
-#define SQLITE_CHECKPOINT_FULL 1     /* Wait for writers, then checkpoint */
-#define SQLITE_CHECKPOINT_RESTART 2  /* Like FULL but wait for readers */
-#define SQLITE_CHECKPOINT_TRUNCATE 3 /* Like RESTART but also truncate WAL */
+#define SQLITE_CHECKPOINT_PASSIVE  0  /* Do as much as possible w/o blocking */
+#define SQLITE_CHECKPOINT_FULL     1  /* Wait for writers, then checkpoint */
+#define SQLITE_CHECKPOINT_RESTART  2  /* Like FULL but wait for readers */
+#define SQLITE_CHECKPOINT_TRUNCATE 3  /* Like RESTART but also truncate WAL */
 
 /*
 ** CAPI3REF: Virtual Table Interface Configuration
@@ -9655,7 +9734,7 @@ SQLITE_API int sqlite3_wal_checkpoint_v2(
 ** of parameters after C depend on which [virtual table configuration option]
 ** is used.
 */
-SQLITE_API int sqlite3_vtab_config(sqlite3 *, int op, ...);
+SQLITE_API int sqlite3_vtab_config(sqlite3*, int op, ...);
 
 /*
 ** CAPI3REF: Virtual Table Configuration Options
@@ -9729,9 +9808,9 @@ SQLITE_API int sqlite3_vtab_config(sqlite3 *, int op, ...);
 ** </dl>
 */
 #define SQLITE_VTAB_CONSTRAINT_SUPPORT 1
-#define SQLITE_VTAB_INNOCUOUS 2
-#define SQLITE_VTAB_DIRECTONLY 3
-#define SQLITE_VTAB_USES_ALL_SCHEMAS 4
+#define SQLITE_VTAB_INNOCUOUS          2
+#define SQLITE_VTAB_DIRECTONLY         3
+#define SQLITE_VTAB_USES_ALL_SCHEMAS   4
 
 /*
 ** CAPI3REF: Determine The Virtual Table Conflict Policy
@@ -9769,7 +9848,7 @@ SQLITE_API int sqlite3_vtab_on_conflict(sqlite3 *);
 ** current implementation, the sqlite3_vtab_nochange() interface does always
 ** returns false for the enhanced [UPDATE FROM] statement.
 */
-SQLITE_API int sqlite3_vtab_nochange(sqlite3_context *);
+SQLITE_API int sqlite3_vtab_nochange(sqlite3_context*);
 
 /*
 ** CAPI3REF: Determine The Collation For a Virtual Table Constraint
@@ -9804,7 +9883,7 @@ SQLITE_API int sqlite3_vtab_nochange(sqlite3_context *);
 ** <li><p> Otherwise, "BINARY" is returned.
 ** </ol>
 */
-SQLITE_API const char *sqlite3_vtab_collation(sqlite3_index_info *, int);
+SQLITE_API const char *sqlite3_vtab_collation(sqlite3_index_info*,int);
 
 /*
 ** CAPI3REF: Determine if a virtual table query is DISTINCT
@@ -9877,7 +9956,7 @@ SQLITE_API const char *sqlite3_vtab_collation(sqlite3_index_info *, int);
 ** valid to do so, on the other hand, might cause SQLite to return incorrect
 ** results.
 */
-SQLITE_API int sqlite3_vtab_distinct(sqlite3_index_info *);
+SQLITE_API int sqlite3_vtab_distinct(sqlite3_index_info*);
 
 /*
 ** CAPI3REF: Identify and handle IN constraints in xBestIndex
@@ -9950,7 +10029,7 @@ SQLITE_API int sqlite3_vtab_distinct(sqlite3_index_info *);
 ** [sqlite3_vtab_in_next()] to find all values on the right-hand side
 ** of the IN constraint.
 */
-SQLITE_API int sqlite3_vtab_in(sqlite3_index_info *, int iCons, int bHandle);
+SQLITE_API int sqlite3_vtab_in(sqlite3_index_info*, int iCons, int bHandle);
 
 /*
 ** CAPI3REF: Find all elements on the right-hand side of an IN constraint.
@@ -9997,8 +10076,7 @@ SQLITE_API int sqlite3_vtab_in(sqlite3_index_info *, int iCons, int bHandle);
 ** implementation needs to retain the *ppOut values for longer, it must make
 ** copies.  The *ppOut values are [protected sqlite3_value|protected].
 */
-SQLITE_API int sqlite3_vtab_in_first(sqlite3_value *pVal,
-                                     sqlite3_value **ppOut);
+SQLITE_API int sqlite3_vtab_in_first(sqlite3_value *pVal, sqlite3_value **ppOut);
 SQLITE_API int sqlite3_vtab_in_next(sqlite3_value *pVal, sqlite3_value **ppOut);
 
 /*
@@ -10041,8 +10119,7 @@ SQLITE_API int sqlite3_vtab_in_next(sqlite3_value *pVal, sqlite3_value **ppOut);
 ** The "_rhs_" in the name of this routine is an abbreviation for
 ** "Right-Hand Side".
 */
-SQLITE_API int sqlite3_vtab_rhs_value(sqlite3_index_info *, int,
-                                      sqlite3_value **ppVal);
+SQLITE_API int sqlite3_vtab_rhs_value(sqlite3_index_info*, int, sqlite3_value **ppVal);
 
 /*
 ** CAPI3REF: Conflict resolution modes
@@ -10058,9 +10135,9 @@ SQLITE_API int sqlite3_vtab_rhs_value(sqlite3_index_info *, int,
 */
 #define SQLITE_ROLLBACK 1
 /* #define SQLITE_IGNORE 2 // Also used by sqlite3_authorizer() callback */
-#define SQLITE_FAIL 3
+#define SQLITE_FAIL     3
 /* #define SQLITE_ABORT 4  // Also an error code */
-#define SQLITE_REPLACE 5
+#define SQLITE_REPLACE  5
 
 /*
 ** CAPI3REF: Prepared Statement Scan Status Opcodes
@@ -10125,14 +10202,14 @@ SQLITE_API int sqlite3_vtab_rhs_value(sqlite3_index_info *, int,
 ** set to -1.
 ** </dl>
 */
-#define SQLITE_SCANSTAT_NLOOP 0
-#define SQLITE_SCANSTAT_NVISIT 1
-#define SQLITE_SCANSTAT_EST 2
-#define SQLITE_SCANSTAT_NAME 3
-#define SQLITE_SCANSTAT_EXPLAIN 4
+#define SQLITE_SCANSTAT_NLOOP    0
+#define SQLITE_SCANSTAT_NVISIT   1
+#define SQLITE_SCANSTAT_EST      2
+#define SQLITE_SCANSTAT_NAME     3
+#define SQLITE_SCANSTAT_EXPLAIN  4
 #define SQLITE_SCANSTAT_SELECTID 5
 #define SQLITE_SCANSTAT_PARENTID 6
-#define SQLITE_SCANSTAT_NCYCLE 7
+#define SQLITE_SCANSTAT_NCYCLE   7
 
 /*
 ** CAPI3REF: Prepared Statement Scan Status
@@ -10172,17 +10249,17 @@ SQLITE_API int sqlite3_vtab_rhs_value(sqlite3_index_info *, int,
 ** See also: [sqlite3_stmt_scanstatus_reset()]
 */
 SQLITE_API int sqlite3_stmt_scanstatus(
-    sqlite3_stmt *pStmt, /* Prepared statement for which info desired */
-    int idx,             /* Index of loop to report on */
-    int iScanStatusOp,   /* Information desired.  SQLITE_SCANSTAT_* */
-    void *pOut           /* Result written here */
+  sqlite3_stmt *pStmt,      /* Prepared statement for which info desired */
+  int idx,                  /* Index of loop to report on */
+  int iScanStatusOp,        /* Information desired.  SQLITE_SCANSTAT_* */
+  void *pOut                /* Result written here */
 );
 SQLITE_API int sqlite3_stmt_scanstatus_v2(
-    sqlite3_stmt *pStmt, /* Prepared statement for which info desired */
-    int idx,             /* Index of loop to report on */
-    int iScanStatusOp,   /* Information desired.  SQLITE_SCANSTAT_* */
-    int flags,           /* Mask of flags defined below */
-    void *pOut           /* Result written here */
+  sqlite3_stmt *pStmt,      /* Prepared statement for which info desired */
+  int idx,                  /* Index of loop to report on */
+  int iScanStatusOp,        /* Information desired.  SQLITE_SCANSTAT_* */
+  int flags,                /* Mask of flags defined below */
+  void *pOut                /* Result written here */
 );
 
 /*
@@ -10200,7 +10277,7 @@ SQLITE_API int sqlite3_stmt_scanstatus_v2(
 ** This API is only available if the library is built with pre-processor
 ** symbol [SQLITE_ENABLE_STMT_SCANSTATUS] defined.
 */
-SQLITE_API void sqlite3_stmt_scanstatus_reset(sqlite3_stmt *);
+SQLITE_API void sqlite3_stmt_scanstatus_reset(sqlite3_stmt*);
 
 /*
 ** CAPI3REF: Flush caches to disk mid-transaction
@@ -10233,7 +10310,7 @@ SQLITE_API void sqlite3_stmt_scanstatus_reset(sqlite3_stmt *);
 ** ^This function does not set the database handle error code or message
 ** returned by the [sqlite3_errcode()] and [sqlite3_errmsg()] functions.
 */
-SQLITE_API int sqlite3_db_cacheflush(sqlite3 *);
+SQLITE_API int sqlite3_db_cacheflush(sqlite3*);
 
 /*
 ** CAPI3REF: The pre-update hook.
@@ -10333,17 +10410,18 @@ SQLITE_API int sqlite3_db_cacheflush(sqlite3 *);
 */
 #if defined(SQLITE_ENABLE_PREUPDATE_HOOK)
 SQLITE_API void *sqlite3_preupdate_hook(
-    sqlite3 *db,
-    void (*xPreUpdate)(
-        void *pCtx,          /* Copy of third arg to preupdate_hook() */
-        sqlite3 *db,         /* Database handle */
-        int op,              /* SQLITE_UPDATE, DELETE or INSERT */
-        char const *zDb,     /* Database name */
-        char const *zName,   /* Table name */
-        sqlite3_int64 iKey1, /* Rowid of row about to be deleted/updated */
-        sqlite3_int64 iKey2  /* New rowid value (for a rowid UPDATE) */
-        ),
-    void *);
+  sqlite3 *db,
+  void(*xPreUpdate)(
+    void *pCtx,                   /* Copy of third arg to preupdate_hook() */
+    sqlite3 *db,                  /* Database handle */
+    int op,                       /* SQLITE_UPDATE, DELETE or INSERT */
+    char const *zDb,              /* Database name */
+    char const *zName,            /* Table name */
+    sqlite3_int64 iKey1,          /* Rowid of row about to be deleted/updated */
+    sqlite3_int64 iKey2           /* New rowid value (for a rowid UPDATE) */
+  ),
+  void*
+);
 SQLITE_API int sqlite3_preupdate_old(sqlite3 *, int, sqlite3_value **);
 SQLITE_API int sqlite3_preupdate_count(sqlite3 *);
 SQLITE_API int sqlite3_preupdate_depth(sqlite3 *);
@@ -10362,7 +10440,7 @@ SQLITE_API int sqlite3_preupdate_blobwrite(sqlite3 *);
 ** called to get back the underlying "errno" that caused the problem, such
 ** as ENOSPC, EAUTH, EISDIR, and so forth.
 */
-SQLITE_API int sqlite3_system_errno(sqlite3 *);
+SQLITE_API int sqlite3_system_errno(sqlite3*);
 
 /*
 ** CAPI3REF: Database Snapshot
@@ -10431,9 +10509,11 @@ typedef struct sqlite3_snapshot {
 ** The [sqlite3_snapshot_get()] interface is only available when the
 ** [SQLITE_ENABLE_SNAPSHOT] compile-time option is used.
 */
-SQLITE_API SQLITE_EXPERIMENTAL int
-sqlite3_snapshot_get(sqlite3 *db, const char *zSchema,
-                     sqlite3_snapshot **ppSnapshot);
+SQLITE_API SQLITE_EXPERIMENTAL int sqlite3_snapshot_get(
+  sqlite3 *db,
+  const char *zSchema,
+  sqlite3_snapshot **ppSnapshot
+);
 
 /*
 ** CAPI3REF: Start a read transaction on an historical snapshot
@@ -10478,9 +10558,11 @@ sqlite3_snapshot_get(sqlite3 *db, const char *zSchema,
 ** The [sqlite3_snapshot_open()] interface is only available when the
 ** [SQLITE_ENABLE_SNAPSHOT] compile-time option is used.
 */
-SQLITE_API SQLITE_EXPERIMENTAL int
-sqlite3_snapshot_open(sqlite3 *db, const char *zSchema,
-                      sqlite3_snapshot *pSnapshot);
+SQLITE_API SQLITE_EXPERIMENTAL int sqlite3_snapshot_open(
+  sqlite3 *db,
+  const char *zSchema,
+  sqlite3_snapshot *pSnapshot
+);
 
 /*
 ** CAPI3REF: Destroy a snapshot
@@ -10493,7 +10575,7 @@ sqlite3_snapshot_open(sqlite3 *db, const char *zSchema,
 ** The [sqlite3_snapshot_free()] interface is only available when the
 ** [SQLITE_ENABLE_SNAPSHOT] compile-time option is used.
 */
-SQLITE_API SQLITE_EXPERIMENTAL void sqlite3_snapshot_free(sqlite3_snapshot *);
+SQLITE_API SQLITE_EXPERIMENTAL void sqlite3_snapshot_free(sqlite3_snapshot*);
 
 /*
 ** CAPI3REF: Compare the ages of two snapshot handles.
@@ -10520,8 +10602,10 @@ SQLITE_API SQLITE_EXPERIMENTAL void sqlite3_snapshot_free(sqlite3_snapshot *);
 ** This interface is only available if SQLite is compiled with the
 ** [SQLITE_ENABLE_SNAPSHOT] option.
 */
-SQLITE_API SQLITE_EXPERIMENTAL int sqlite3_snapshot_cmp(sqlite3_snapshot *p1,
-                                                        sqlite3_snapshot *p2);
+SQLITE_API SQLITE_EXPERIMENTAL int sqlite3_snapshot_cmp(
+  sqlite3_snapshot *p1,
+  sqlite3_snapshot *p2
+);
 
 /*
 ** CAPI3REF: Recover snapshots from a wal file
@@ -10546,8 +10630,7 @@ SQLITE_API SQLITE_EXPERIMENTAL int sqlite3_snapshot_cmp(sqlite3_snapshot *p1,
 ** This interface is only available if SQLite is compiled with the
 ** [SQLITE_ENABLE_SNAPSHOT] option.
 */
-SQLITE_API SQLITE_EXPERIMENTAL int sqlite3_snapshot_recover(sqlite3 *db,
-                                                            const char *zDb);
+SQLITE_API SQLITE_EXPERIMENTAL int sqlite3_snapshot_recover(sqlite3 *db, const char *zDb);
 
 /*
 ** CAPI3REF: Serialize a database
@@ -10593,10 +10676,10 @@ SQLITE_API SQLITE_EXPERIMENTAL int sqlite3_snapshot_recover(sqlite3 *db,
 ** [SQLITE_OMIT_DESERIALIZE] option.
 */
 SQLITE_API unsigned char *sqlite3_serialize(
-    sqlite3 *db,           /* The database connection */
-    const char *zSchema,   /* Which DB to serialize. ex: "main", "temp", ... */
-    sqlite3_int64 *piSize, /* Write size of the DB here, if not NULL */
-    unsigned int mFlags    /* Zero or more SQLITE_SERIALIZE_* flags */
+  sqlite3 *db,           /* The database connection */
+  const char *zSchema,   /* Which DB to serialize. ex: "main", "temp", ... */
+  sqlite3_int64 *piSize, /* Write size of the DB here, if not NULL */
+  unsigned int mFlags    /* Zero or more SQLITE_SERIALIZE_* flags */
 );
 
 /*
@@ -10613,7 +10696,7 @@ SQLITE_API unsigned char *sqlite3_serialize(
 ** using a contiguous in-memory database if it has been initialized by a
 ** prior call to [sqlite3_deserialize()].
 */
-#define SQLITE_SERIALIZE_NOCOPY 0x001 /* Do no memory allocations */
+#define SQLITE_SERIALIZE_NOCOPY 0x001   /* Do no memory allocations */
 
 /*
 ** CAPI3REF: Deserialize a database
@@ -10659,12 +10742,12 @@ SQLITE_API unsigned char *sqlite3_serialize(
 ** [SQLITE_OMIT_DESERIALIZE] option.
 */
 SQLITE_API int sqlite3_deserialize(
-    sqlite3 *db,          /* The database connection */
-    const char *zSchema,  /* Which DB to reopen with the deserialization */
-    unsigned char *pData, /* The serialized database content */
-    sqlite3_int64 szDb,   /* Number bytes in the deserialization */
-    sqlite3_int64 szBuf,  /* Total size of buffer pData[] */
-    unsigned mFlags       /* Zero or more SQLITE_DESERIALIZE_* flags */
+  sqlite3 *db,            /* The database connection */
+  const char *zSchema,    /* Which DB to reopen with the deserialization */
+  unsigned char *pData,   /* The serialized database content */
+  sqlite3_int64 szDb,     /* Number bytes in the deserialization */
+  sqlite3_int64 szBuf,    /* Total size of buffer pData[] */
+  unsigned mFlags         /* Zero or more SQLITE_DESERIALIZE_* flags */
 );
 
 /*
@@ -10689,32 +10772,32 @@ SQLITE_API int sqlite3_deserialize(
 ** should be treated as read-only.
 */
 #define SQLITE_DESERIALIZE_FREEONCLOSE 1 /* Call sqlite3_free() on close */
-#define SQLITE_DESERIALIZE_RESIZEABLE 2  /* Resize using sqlite3_realloc64() */
-#define SQLITE_DESERIALIZE_READONLY 4    /* Database is read-only */
+#define SQLITE_DESERIALIZE_RESIZEABLE  2 /* Resize using sqlite3_realloc64() */
+#define SQLITE_DESERIALIZE_READONLY    4 /* Database is read-only */
 
 /*
 ** Undo the hack that converts floating point types to integer for
 ** builds on processors without floating point support.
 */
 #ifdef SQLITE_OMIT_FLOATING_POINT
-#undef double
+# undef double
 #endif
 
 #if defined(__wasi__)
-#undef SQLITE_WASI
-#define SQLITE_WASI 1
-#undef SQLITE_OMIT_WAL
-#define SQLITE_OMIT_WAL 1 /* because it requires shared memory APIs */
-#ifndef SQLITE_OMIT_LOAD_EXTENSION
-#define SQLITE_OMIT_LOAD_EXTENSION
-#endif
-#ifndef SQLITE_THREADSAFE
-#define SQLITE_THREADSAFE 0
-#endif
+# undef SQLITE_WASI
+# define SQLITE_WASI 1
+# undef SQLITE_OMIT_WAL
+# define SQLITE_OMIT_WAL 1/* because it requires shared memory APIs */
+# ifndef SQLITE_OMIT_LOAD_EXTENSION
+#  define SQLITE_OMIT_LOAD_EXTENSION
+# endif
+# ifndef SQLITE_THREADSAFE
+#  define SQLITE_THREADSAFE 0
+# endif
 #endif
 
 #ifdef __cplusplus
-} /* End of the 'extern "C"' block */
+}  /* End of the 'extern "C"' block */
 #endif
 #endif /* SQLITE3_H */
 
@@ -10735,6 +10818,7 @@ SQLITE_API int sqlite3_deserialize(
 #ifndef _SQLITE3RTREE_H_
 #define _SQLITE3RTREE_H_
 
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -10746,9 +10830,9 @@ typedef struct sqlite3_rtree_query_info sqlite3_rtree_query_info;
 ** SQLITE_RTREE_INT_ONLY compile-time option.
 */
 #ifdef SQLITE_RTREE_INT_ONLY
-typedef sqlite3_int64 sqlite3_rtree_dbl;
+  typedef sqlite3_int64 sqlite3_rtree_dbl;
 #else
-typedef double sqlite3_rtree_dbl;
+  typedef double sqlite3_rtree_dbl;
 #endif
 
 /*
@@ -10758,20 +10842,23 @@ typedef double sqlite3_rtree_dbl;
 **   SELECT ... FROM <rtree> WHERE <rtree col> MATCH $zGeom(... params ...)
 */
 SQLITE_API int sqlite3_rtree_geometry_callback(
-    sqlite3 *db, const char *zGeom,
-    int (*xGeom)(sqlite3_rtree_geometry *, int, sqlite3_rtree_dbl *, int *),
-    void *pContext);
+  sqlite3 *db,
+  const char *zGeom,
+  int (*xGeom)(sqlite3_rtree_geometry*, int, sqlite3_rtree_dbl*,int*),
+  void *pContext
+);
+
 
 /*
 ** A pointer to a structure of the following type is passed as the first
 ** argument to callbacks registered using rtree_geometry_callback().
 */
 struct sqlite3_rtree_geometry {
-  void *pContext;            /* Copy of pContext passed to s_r_g_c() */
-  int nParam;                /* Size of array aParam[] */
-  sqlite3_rtree_dbl *aParam; /* Parameters passed to SQL geom function */
-  void *pUser;               /* Callback implementation user data */
-  void (*xDelUser)(void *);  /* Called by SQLite to clean up pUser */
+  void *pContext;                 /* Copy of pContext passed to s_r_g_c() */
+  int nParam;                     /* Size of array aParam[] */
+  sqlite3_rtree_dbl *aParam;      /* Parameters passed to SQL geom function */
+  void *pUser;                    /* Callback implementation user data */
+  void (*xDelUser)(void *);       /* Called by SQLite to clean up pUser */
 };
 
 /*
@@ -10780,10 +10867,14 @@ struct sqlite3_rtree_geometry {
 **
 **   SELECT ... FROM <rtree> WHERE <rtree col> MATCH $zQueryFunc(... params ...)
 */
-SQLITE_API int
-sqlite3_rtree_query_callback(sqlite3 *db, const char *zQueryFunc,
-                             int (*xQueryFunc)(sqlite3_rtree_query_info *),
-                             void *pContext, void (*xDestructor)(void *));
+SQLITE_API int sqlite3_rtree_query_callback(
+  sqlite3 *db,
+  const char *zQueryFunc,
+  int (*xQueryFunc)(sqlite3_rtree_query_info*),
+  void *pContext,
+  void (*xDestructor)(void*)
+);
+
 
 /*
 ** A pointer to a structure of the following type is passed as the
@@ -10795,37 +10886,38 @@ sqlite3_rtree_query_callback(sqlite3 *db, const char *zQueryFunc,
 ** sqlite3_rtree_geometry.
 */
 struct sqlite3_rtree_query_info {
-  void *pContext;                 /* pContext from when function registered */
-  int nParam;                     /* Number of function parameters */
-  sqlite3_rtree_dbl *aParam;      /* value of function parameters */
-  void *pUser;                    /* callback can use this, if desired */
-  void (*xDelUser)(void *);       /* function to free pUser */
-  sqlite3_rtree_dbl *aCoord;      /* Coordinates of node or entry to check */
-  unsigned int *anQueue;          /* Number of pending entries in the queue */
-  int nCoord;                     /* Number of coordinates */
-  int iLevel;                     /* Level of current node or entry */
-  int mxLevel;                    /* The largest iLevel value in the tree */
-  sqlite3_int64 iRowid;           /* Rowid for current entry */
-  sqlite3_rtree_dbl rParentScore; /* Score of parent node */
-  int eParentWithin;              /* Visibility of parent node */
-  int eWithin;                    /* OUT: Visibility */
-  sqlite3_rtree_dbl rScore;       /* OUT: Write the score here */
+  void *pContext;                   /* pContext from when function registered */
+  int nParam;                       /* Number of function parameters */
+  sqlite3_rtree_dbl *aParam;        /* value of function parameters */
+  void *pUser;                      /* callback can use this, if desired */
+  void (*xDelUser)(void*);          /* function to free pUser */
+  sqlite3_rtree_dbl *aCoord;        /* Coordinates of node or entry to check */
+  unsigned int *anQueue;            /* Number of pending entries in the queue */
+  int nCoord;                       /* Number of coordinates */
+  int iLevel;                       /* Level of current node or entry */
+  int mxLevel;                      /* The largest iLevel value in the tree */
+  sqlite3_int64 iRowid;             /* Rowid for current entry */
+  sqlite3_rtree_dbl rParentScore;   /* Score of parent node */
+  int eParentWithin;                /* Visibility of parent node */
+  int eWithin;                      /* OUT: Visibility */
+  sqlite3_rtree_dbl rScore;         /* OUT: Write the score here */
   /* The following fields are only available in 3.8.11 and later */
-  sqlite3_value **apSqlParam; /* Original SQL values of parameters */
+  sqlite3_value **apSqlParam;       /* Original SQL values of parameters */
 };
 
 /*
 ** Allowed values for sqlite3_rtree_query.eWithin and .eParentWithin.
 */
-#define NOT_WITHIN 0    /* Object completely outside of query region */
-#define PARTLY_WITHIN 1 /* Object partially overlaps query region */
-#define FULLY_WITHIN 2  /* Object fully contained within query region */
+#define NOT_WITHIN       0   /* Object completely outside of query region */
+#define PARTLY_WITHIN    1   /* Object partially overlaps query region */
+#define FULLY_WITHIN     2   /* Object fully contained within query region */
+
 
 #ifdef __cplusplus
-} /* end of the 'extern "C"' block */
+}  /* end of the 'extern "C"' block */
 #endif
 
-#endif /* ifndef _SQLITE3RTREE_H_ */
+#endif  /* ifndef _SQLITE3RTREE_H_ */
 
 /******** End of sqlite3rtree.h *********/
 /******** Begin file sqlite3session.h *********/
@@ -10839,6 +10931,7 @@ struct sqlite3_rtree_query_info {
 #ifdef __cplusplus
 extern "C" {
 #endif
+
 
 /*
 ** CAPI3REF: Session Object Handle
@@ -10887,10 +10980,10 @@ typedef struct sqlite3_changeset_iter sqlite3_changeset_iter;
 ** attached database. It is not an error if database zDb is not attached
 ** to the database when the session object is created.
 */
-SQLITE_API int
-sqlite3session_create(sqlite3 *db,                /* Database handle */
-                      const char *zDb,            /* Name of db (e.g. "main") */
-                      sqlite3_session **ppSession /* OUT: New session object */
+SQLITE_API int sqlite3session_create(
+  sqlite3 *db,                    /* Database handle */
+  const char *zDb,                /* Name of db (e.g. "main") */
+  sqlite3_session **ppSession     /* OUT: New session object */
 );
 
 /*
@@ -10917,8 +11010,7 @@ SQLITE_API void sqlite3session_delete(sqlite3_session *pSession);
 ** [SQLITE_SESSION_OBJCONFIG_SIZE] and [SQLITE_SESSION_OBJCONFIG_ROWID].
 **
 */
-SQLITE_API int sqlite3session_object_config(sqlite3_session *, int op,
-                                            void *pArg);
+SQLITE_API int sqlite3session_object_config(sqlite3_session*, int op, void *pArg);
 
 /*
 ** CAPI3REF: Options for sqlite3session_object_config
@@ -10952,7 +11044,7 @@ SQLITE_API int sqlite3session_object_config(sqlite3_session *, int op,
 **   It is an error (SQLITE_MISUSE) to attempt to modify this setting after
 **   the first table has been attached to the session object.
 */
-#define SQLITE_SESSION_OBJCONFIG_SIZE 1
+#define SQLITE_SESSION_OBJCONFIG_SIZE  1
 #define SQLITE_SESSION_OBJCONFIG_ROWID 2
 
 /*
@@ -11003,8 +11095,7 @@ SQLITE_API int sqlite3session_enable(sqlite3_session *pSession, int bEnable);
 ** The return value indicates the final state of the indirect flag: 0 if
 ** it is clear, or 1 if it is set.
 */
-SQLITE_API int sqlite3session_indirect(sqlite3_session *pSession,
-                                       int bIndirect);
+SQLITE_API int sqlite3session_indirect(sqlite3_session *pSession, int bIndirect);
 
 /*
 ** CAPI3REF: Attach A Table To A Session Object
@@ -11064,9 +11155,9 @@ SQLITE_API int sqlite3session_indirect(sqlite3_session *pSession,
 ** sqlite3changeset_apply() function silently ignore any modifications to the
 ** sqlite_stat1 table that are part of a changeset or patchset.
 */
-SQLITE_API int
-sqlite3session_attach(sqlite3_session *pSession, /* Session object */
-                      const char *zTab           /* Table name */
+SQLITE_API int sqlite3session_attach(
+  sqlite3_session *pSession,      /* Session object */
+  const char *zTab                /* Table name */
 );
 
 /*
@@ -11080,11 +11171,12 @@ sqlite3session_attach(sqlite3_session *pSession, /* Session object */
 ** attached, xFilter will not be called again.
 */
 SQLITE_API void sqlite3session_table_filter(
-    sqlite3_session *pSession,      /* Session object */
-    int (*xFilter)(void *pCtx,      /* Copy of third arg to _filter_table() */
-                   const char *zTab /* Table name */
-                   ),
-    void *pCtx /* First argument passed to xFilter */
+  sqlite3_session *pSession,      /* Session object */
+  int(*xFilter)(
+    void *pCtx,                   /* Copy of third arg to _filter_table() */
+    const char *zTab              /* Table name */
+  ),
+  void *pCtx                      /* First argument passed to xFilter */
 );
 
 /*
@@ -11193,9 +11285,9 @@ SQLITE_API void sqlite3session_table_filter(
 ** resulting changeset will contain an UPDATE change that updates both fields.
 */
 SQLITE_API int sqlite3session_changeset(
-    sqlite3_session *pSession, /* Session object */
-    int *pnChangeset,          /* OUT: Size of buffer at *ppChangeset */
-    void **ppChangeset         /* OUT: Buffer containing changeset */
+  sqlite3_session *pSession,      /* Session object */
+  int *pnChangeset,               /* OUT: Size of buffer at *ppChangeset */
+  void **ppChangeset              /* OUT: Buffer containing changeset */
 );
 
 /*
@@ -11212,8 +11304,7 @@ SQLITE_API int sqlite3session_changeset(
 ** called. The final changeset size might be equal to or smaller than the
 ** size in bytes returned by this function.
 */
-SQLITE_API sqlite3_int64
-sqlite3session_changeset_size(sqlite3_session *pSession);
+SQLITE_API sqlite3_int64 sqlite3session_changeset_size(sqlite3_session *pSession);
 
 /*
 ** CAPI3REF: Load The Difference Between Tables Into A Session
@@ -11272,9 +11363,13 @@ sqlite3session_changeset_size(sqlite3_session *pSession);
 ** message. It is the responsibility of the caller to free this buffer using
 ** sqlite3_free().
 */
-SQLITE_API int sqlite3session_diff(sqlite3_session *pSession,
-                                   const char *zFromDb, const char *zTbl,
-                                   char **pzErrMsg);
+SQLITE_API int sqlite3session_diff(
+  sqlite3_session *pSession,
+  const char *zFromDb,
+  const char *zTbl,
+  char **pzErrMsg
+);
+
 
 /*
 ** CAPI3REF: Generate A Patchset From A Session Object
@@ -11306,9 +11401,9 @@ SQLITE_API int sqlite3session_diff(sqlite3_session *pSession,
 ** they were attached to the session object).
 */
 SQLITE_API int sqlite3session_patchset(
-    sqlite3_session *pSession, /* Session object */
-    int *pnPatchset,           /* OUT: Size of buffer at *ppPatchset */
-    void **ppPatchset          /* OUT: Buffer containing patchset */
+  sqlite3_session *pSession,      /* Session object */
+  int *pnPatchset,                /* OUT: Size of buffer at *ppPatchset */
+  void **ppPatchset               /* OUT: Buffer containing patchset */
 );
 
 /*
@@ -11378,15 +11473,15 @@ SQLITE_API sqlite3_int64 sqlite3session_memory_used(sqlite3_session *pSession);
 ** and therefore subject to change.
 */
 SQLITE_API int sqlite3changeset_start(
-    sqlite3_changeset_iter **pp, /* OUT: New changeset iterator handle */
-    int nChangeset,              /* Size of changeset blob in bytes */
-    void *pChangeset             /* Pointer to blob containing changeset */
+  sqlite3_changeset_iter **pp,    /* OUT: New changeset iterator handle */
+  int nChangeset,                 /* Size of changeset blob in bytes */
+  void *pChangeset                /* Pointer to blob containing changeset */
 );
 SQLITE_API int sqlite3changeset_start_v2(
-    sqlite3_changeset_iter **pp, /* OUT: New changeset iterator handle */
-    int nChangeset,              /* Size of changeset blob in bytes */
-    void *pChangeset,            /* Pointer to blob containing changeset */
-    int flags                    /* SESSION_CHANGESETSTART_* flags */
+  sqlite3_changeset_iter **pp,    /* OUT: New changeset iterator handle */
+  int nChangeset,                 /* Size of changeset blob in bytes */
+  void *pChangeset,               /* Pointer to blob containing changeset */
+  int flags                       /* SESSION_CHANGESETSTART_* flags */
 );
 
 /*
@@ -11400,7 +11495,8 @@ SQLITE_API int sqlite3changeset_start_v2(
 **   inverting a changeset using sqlite3changeset_invert() before applying it.
 **   It is an error to specify this flag with a patchset.
 */
-#define SQLITE_CHANGESETSTART_INVERT 0x0002
+#define SQLITE_CHANGESETSTART_INVERT        0x0002
+
 
 /*
 ** CAPI3REF: Advance A Changeset Iterator
@@ -11443,8 +11539,7 @@ SQLITE_API int sqlite3changeset_next(sqlite3_changeset_iter *pIter);
 ** *pOp is set to one of [SQLITE_INSERT], [SQLITE_DELETE] or [SQLITE_UPDATE],
 ** depending on the type of change that the iterator currently points to;
 **
-** *pnCol is set to the number of columns in the table affected by the change;
-*and
+** *pnCol is set to the number of columns in the table affected by the change; and
 **
 ** *pzTab is set to point to a nul-terminated utf-8 encoded string containing
 ** the name of the table affected by the current change. The buffer remains
@@ -11460,12 +11555,12 @@ SQLITE_API int sqlite3changeset_next(sqlite3_changeset_iter *pIter);
 ** SQLite error code is returned. The values of the output variables may not
 ** be trusted in this case.
 */
-SQLITE_API int
-sqlite3changeset_op(sqlite3_changeset_iter *pIter, /* Iterator object */
-                    const char **pzTab, /* OUT: Pointer to table name */
-                    int *pnCol,         /* OUT: Number of columns in table */
-                    int *pOp,       /* OUT: SQLITE_INSERT, DELETE or UPDATE */
-                    int *pbIndirect /* OUT: True for an 'indirect' change */
+SQLITE_API int sqlite3changeset_op(
+  sqlite3_changeset_iter *pIter,  /* Iterator object */
+  const char **pzTab,             /* OUT: Pointer to table name */
+  int *pnCol,                     /* OUT: Number of columns in table */
+  int *pOp,                       /* OUT: SQLITE_INSERT, DELETE or UPDATE */
+  int *pbIndirect                 /* OUT: True for an 'indirect' change */
 );
 
 /*
@@ -11495,9 +11590,9 @@ sqlite3changeset_op(sqlite3_changeset_iter *pIter, /* Iterator object */
 ** above.
 */
 SQLITE_API int sqlite3changeset_pk(
-    sqlite3_changeset_iter *pIter, /* Iterator object */
-    unsigned char **pabPK, /* OUT: Array of boolean - true for PK cols */
-    int *pnCol             /* OUT: Number of entries in output array */
+  sqlite3_changeset_iter *pIter,  /* Iterator object */
+  unsigned char **pabPK,          /* OUT: Array of boolean - true for PK cols */
+  int *pnCol                      /* OUT: Number of entries in output array */
 );
 
 /*
@@ -11526,9 +11621,9 @@ SQLITE_API int sqlite3changeset_pk(
 ** is returned and *ppValue is set to NULL.
 */
 SQLITE_API int sqlite3changeset_old(
-    sqlite3_changeset_iter *pIter, /* Changeset iterator */
-    int iVal,                      /* Column number */
-    sqlite3_value **ppValue        /* OUT: Old value (or NULL pointer) */
+  sqlite3_changeset_iter *pIter,  /* Changeset iterator */
+  int iVal,                       /* Column number */
+  sqlite3_value **ppValue         /* OUT: Old value (or NULL pointer) */
 );
 
 /*
@@ -11560,9 +11655,9 @@ SQLITE_API int sqlite3changeset_old(
 ** is returned and *ppValue is set to NULL.
 */
 SQLITE_API int sqlite3changeset_new(
-    sqlite3_changeset_iter *pIter, /* Changeset iterator */
-    int iVal,                      /* Column number */
-    sqlite3_value **ppValue        /* OUT: New value (or NULL pointer) */
+  sqlite3_changeset_iter *pIter,  /* Changeset iterator */
+  int iVal,                       /* Column number */
+  sqlite3_value **ppValue         /* OUT: New value (or NULL pointer) */
 );
 
 /*
@@ -11588,9 +11683,9 @@ SQLITE_API int sqlite3changeset_new(
 ** is returned and *ppValue is set to NULL.
 */
 SQLITE_API int sqlite3changeset_conflict(
-    sqlite3_changeset_iter *pIter, /* Changeset iterator */
-    int iVal,                      /* Column number */
-    sqlite3_value **ppValue        /* OUT: Value from conflicting row */
+  sqlite3_changeset_iter *pIter,  /* Changeset iterator */
+  int iVal,                       /* Column number */
+  sqlite3_value **ppValue         /* OUT: Value from conflicting row */
 );
 
 /*
@@ -11605,9 +11700,10 @@ SQLITE_API int sqlite3changeset_conflict(
 ** In all other cases this function returns SQLITE_MISUSE.
 */
 SQLITE_API int sqlite3changeset_fk_conflicts(
-    sqlite3_changeset_iter *pIter, /* Changeset iterator */
-    int *pnOut                     /* OUT: Number of FK violations */
+  sqlite3_changeset_iter *pIter,  /* Changeset iterator */
+  int *pnOut                      /* OUT: Number of FK violations */
 );
+
 
 /*
 ** CAPI3REF: Finalize A Changeset Iterator
@@ -11669,10 +11765,9 @@ SQLITE_API int sqlite3changeset_finalize(sqlite3_changeset_iter *pIter);
 ** WARNING/TODO: This function currently assumes that the input is a valid
 ** changeset. If it is not, the results are undefined.
 */
-SQLITE_API int sqlite3changeset_invert(int nIn,
-                                       const void *pIn, /* Input changeset */
-                                       int *pnOut,
-                                       void **ppOut /* OUT: Inverse of input */
+SQLITE_API int sqlite3changeset_invert(
+  int nIn, const void *pIn,       /* Input changeset */
+  int *pnOut, void **ppOut        /* OUT: Inverse of input */
 );
 
 /*
@@ -11702,22 +11797,26 @@ SQLITE_API int sqlite3changeset_invert(int nIn,
 ** Refer to the sqlite3_changegroup documentation below for details.
 */
 SQLITE_API int sqlite3changeset_concat(
-    int nA,      /* Number of bytes in buffer pA */
-    void *pA,    /* Pointer to buffer containing changeset A */
-    int nB,      /* Number of bytes in buffer pB */
-    void *pB,    /* Pointer to buffer containing changeset B */
-    int *pnOut,  /* OUT: Number of bytes in output changeset */
-    void **ppOut /* OUT: Buffer containing output changeset */
+  int nA,                         /* Number of bytes in buffer pA */
+  void *pA,                       /* Pointer to buffer containing changeset A */
+  int nB,                         /* Number of bytes in buffer pB */
+  void *pB,                       /* Pointer to buffer containing changeset B */
+  int *pnOut,                     /* OUT: Number of bytes in output changeset */
+  void **ppOut                    /* OUT: Buffer containing output changeset */
 );
+
 
 /*
 ** CAPI3REF: Upgrade the Schema of a Changeset/Patchset
 */
-SQLITE_API int sqlite3changeset_upgrade(sqlite3 *db, const char *zDb, int nIn,
-                                        const void *pIn, /* Input changeset */
-                                        int *pnOut,
-                                        void **ppOut /* OUT: Inverse of input */
+SQLITE_API int sqlite3changeset_upgrade(
+  sqlite3 *db,
+  const char *zDb,
+  int nIn, const void *pIn,       /* Input changeset */
+  int *pnOut, void **ppOut        /* OUT: Inverse of input */
 );
+
+
 
 /*
 ** CAPI3REF: Changegroup Handle
@@ -11795,8 +11894,7 @@ SQLITE_API int sqlite3changegroup_new(sqlite3_changegroup **pp);
 ** changesets that have different numbers of columns for a single table
 ** within a changegroup, provided that they are otherwise compatible.
 */
-SQLITE_API int sqlite3changegroup_schema(sqlite3_changegroup *, sqlite3 *,
-                                         const char *zDb);
+SQLITE_API int sqlite3changegroup_schema(sqlite3_changegroup*, sqlite3*, const char *zDb);
 
 /*
 ** CAPI3REF: Add A Changeset To A Changegroup
@@ -11879,8 +11977,7 @@ SQLITE_API int sqlite3changegroup_schema(sqlite3_changegroup *, sqlite3 *,
 ** In all cases, if an error occurs the state of the final contents of the
 ** changegroup is undefined. If no error occurs, SQLITE_OK is returned.
 */
-SQLITE_API int sqlite3changegroup_add(sqlite3_changegroup *, int nData,
-                                      void *pData);
+SQLITE_API int sqlite3changegroup_add(sqlite3_changegroup*, int nData, void *pData);
 
 /*
 ** CAPI3REF: Obtain A Composite Changeset From A Changegroup
@@ -11907,17 +12004,17 @@ SQLITE_API int sqlite3changegroup_add(sqlite3_changegroup *, int nData,
 ** responsibility of the caller to eventually free the buffer using a
 ** call to sqlite3_free().
 */
-SQLITE_API int
-sqlite3changegroup_output(sqlite3_changegroup *,
-                          int *pnData, /* OUT: Size of output buffer in bytes */
-                          void **ppData /* OUT: Pointer to output buffer */
+SQLITE_API int sqlite3changegroup_output(
+  sqlite3_changegroup*,
+  int *pnData,                    /* OUT: Size of output buffer in bytes */
+  void **ppData                   /* OUT: Pointer to output buffer */
 );
 
 /*
 ** CAPI3REF: Delete A Changegroup Object
 ** DESTRUCTOR: sqlite3_changegroup
 */
-SQLITE_API void sqlite3changegroup_delete(sqlite3_changegroup *);
+SQLITE_API void sqlite3changegroup_delete(sqlite3_changegroup*);
 
 /*
 ** CAPI3REF: Apply A Changeset To A Database
@@ -12078,34 +12175,36 @@ SQLITE_API void sqlite3changegroup_delete(sqlite3_changegroup *);
 ** and therefore subject to change.
 */
 SQLITE_API int sqlite3changeset_apply(
-    sqlite3 *db,               /* Apply change to "main" db of this handle */
-    int nChangeset,            /* Size of changeset in bytes */
-    void *pChangeset,          /* Changeset blob */
-    int (*xFilter)(void *pCtx, /* Copy of sixth arg to _apply() */
-                   const char *zTab /* Table name */
-                   ),
-    int (*xConflict)(
-        void *pCtx,               /* Copy of sixth arg to _apply() */
-        int eConflict,            /* DATA, MISSING, CONFLICT, CONSTRAINT */
-        sqlite3_changeset_iter *p /* Handle describing change and conflict */
-        ),
-    void *pCtx /* First argument passed to xConflict */
+  sqlite3 *db,                    /* Apply change to "main" db of this handle */
+  int nChangeset,                 /* Size of changeset in bytes */
+  void *pChangeset,               /* Changeset blob */
+  int(*xFilter)(
+    void *pCtx,                   /* Copy of sixth arg to _apply() */
+    const char *zTab              /* Table name */
+  ),
+  int(*xConflict)(
+    void *pCtx,                   /* Copy of sixth arg to _apply() */
+    int eConflict,                /* DATA, MISSING, CONFLICT, CONSTRAINT */
+    sqlite3_changeset_iter *p     /* Handle describing change and conflict */
+  ),
+  void *pCtx                      /* First argument passed to xConflict */
 );
 SQLITE_API int sqlite3changeset_apply_v2(
-    sqlite3 *db,               /* Apply change to "main" db of this handle */
-    int nChangeset,            /* Size of changeset in bytes */
-    void *pChangeset,          /* Changeset blob */
-    int (*xFilter)(void *pCtx, /* Copy of sixth arg to _apply() */
-                   const char *zTab /* Table name */
-                   ),
-    int (*xConflict)(
-        void *pCtx,               /* Copy of sixth arg to _apply() */
-        int eConflict,            /* DATA, MISSING, CONFLICT, CONSTRAINT */
-        sqlite3_changeset_iter *p /* Handle describing change and conflict */
-        ),
-    void *pCtx,                     /* First argument passed to xConflict */
-    void **ppRebase, int *pnRebase, /* OUT: Rebase data */
-    int flags                       /* SESSION_CHANGESETAPPLY_* flags */
+  sqlite3 *db,                    /* Apply change to "main" db of this handle */
+  int nChangeset,                 /* Size of changeset in bytes */
+  void *pChangeset,               /* Changeset blob */
+  int(*xFilter)(
+    void *pCtx,                   /* Copy of sixth arg to _apply() */
+    const char *zTab              /* Table name */
+  ),
+  int(*xConflict)(
+    void *pCtx,                   /* Copy of sixth arg to _apply() */
+    int eConflict,                /* DATA, MISSING, CONFLICT, CONSTRAINT */
+    sqlite3_changeset_iter *p     /* Handle describing change and conflict */
+  ),
+  void *pCtx,                     /* First argument passed to xConflict */
+  void **ppRebase, int *pnRebase, /* OUT: Rebase data */
+  int flags                       /* SESSION_CHANGESETAPPLY_* flags */
 );
 
 /*
@@ -12148,10 +12247,10 @@ SQLITE_API int sqlite3changeset_apply_v2(
 **   DELETE NO ACTION", even if they are actually CASCADE, RESTRICT, SET NULL
 **   or SET DEFAULT.
 */
-#define SQLITE_CHANGESETAPPLY_NOSAVEPOINT 0x0001
-#define SQLITE_CHANGESETAPPLY_INVERT 0x0002
-#define SQLITE_CHANGESETAPPLY_IGNORENOOP 0x0004
-#define SQLITE_CHANGESETAPPLY_FKNOACTION 0x0008
+#define SQLITE_CHANGESETAPPLY_NOSAVEPOINT   0x0001
+#define SQLITE_CHANGESETAPPLY_INVERT        0x0002
+#define SQLITE_CHANGESETAPPLY_IGNORENOOP    0x0004
+#define SQLITE_CHANGESETAPPLY_FKNOACTION    0x0008
 
 /*
 ** CAPI3REF: Constants Passed To The Conflict Handler
@@ -12208,10 +12307,10 @@ SQLITE_API int sqlite3changeset_apply_v2(
 **
 ** </dl>
 */
-#define SQLITE_CHANGESET_DATA 1
-#define SQLITE_CHANGESET_NOTFOUND 2
-#define SQLITE_CHANGESET_CONFLICT 3
-#define SQLITE_CHANGESET_CONSTRAINT 4
+#define SQLITE_CHANGESET_DATA        1
+#define SQLITE_CHANGESET_NOTFOUND    2
+#define SQLITE_CHANGESET_CONFLICT    3
+#define SQLITE_CHANGESET_CONSTRAINT  4
 #define SQLITE_CHANGESET_FOREIGN_KEY 5
 
 /*
@@ -12245,9 +12344,9 @@ SQLITE_API int sqlite3changeset_apply_v2(
 **   and the call to sqlite3changeset_apply() returns SQLITE_ABORT.
 ** </dl>
 */
-#define SQLITE_CHANGESET_OMIT 0
-#define SQLITE_CHANGESET_REPLACE 1
-#define SQLITE_CHANGESET_ABORT 2
+#define SQLITE_CHANGESET_OMIT       0
+#define SQLITE_CHANGESET_REPLACE    1
+#define SQLITE_CHANGESET_ABORT      2
 
 /*
 ** CAPI3REF: Rebasing changesets
@@ -12369,8 +12468,10 @@ SQLITE_API int sqlite3rebaser_create(sqlite3_rebaser **ppNew);
 ** bytes), which must have been obtained from a previous call to
 ** sqlite3changeset_apply_v2().
 */
-SQLITE_API int sqlite3rebaser_configure(sqlite3_rebaser *, int nRebase,
-                                        const void *pRebase);
+SQLITE_API int sqlite3rebaser_configure(
+  sqlite3_rebaser*,
+  int nRebase, const void *pRebase
+);
 
 /*
 ** CAPI3REF: Rebase a changeset
@@ -12386,8 +12487,11 @@ SQLITE_API int sqlite3rebaser_configure(sqlite3_rebaser *, int nRebase,
 ** sqlite3_free(). Otherwise, if an error occurs, (*ppOut) and (*pnOut)
 ** are set to zero and an SQLite error code returned.
 */
-SQLITE_API int sqlite3rebaser_rebase(sqlite3_rebaser *, int nIn,
-                                     const void *pIn, int *pnOut, void **ppOut);
+SQLITE_API int sqlite3rebaser_rebase(
+  sqlite3_rebaser*,
+  int nIn, const void *pIn,
+  int *pnOut, void **ppOut
+);
 
 /*
 ** CAPI3REF: Delete a changeset rebaser object.
@@ -12490,64 +12594,87 @@ SQLITE_API void sqlite3rebaser_delete(sqlite3_rebaser *p);
 ** no guarantees are made as to the size of the chunks of data returned.
 */
 SQLITE_API int sqlite3changeset_apply_strm(
-    sqlite3 *db, /* Apply change to "main" db of this handle */
-    int (*xInput)(void *pIn, void *pData, int *pnData), /* Input function */
-    void *pIn,                      /* First arg for xInput */
-    int (*xFilter)(void *pCtx,      /* Copy of sixth arg to _apply() */
-                   const char *zTab /* Table name */
-                   ),
-    int (*xConflict)(
-        void *pCtx,               /* Copy of sixth arg to _apply() */
-        int eConflict,            /* DATA, MISSING, CONFLICT, CONSTRAINT */
-        sqlite3_changeset_iter *p /* Handle describing change and conflict */
-        ),
-    void *pCtx /* First argument passed to xConflict */
+  sqlite3 *db,                    /* Apply change to "main" db of this handle */
+  int (*xInput)(void *pIn, void *pData, int *pnData), /* Input function */
+  void *pIn,                                          /* First arg for xInput */
+  int(*xFilter)(
+    void *pCtx,                   /* Copy of sixth arg to _apply() */
+    const char *zTab              /* Table name */
+  ),
+  int(*xConflict)(
+    void *pCtx,                   /* Copy of sixth arg to _apply() */
+    int eConflict,                /* DATA, MISSING, CONFLICT, CONSTRAINT */
+    sqlite3_changeset_iter *p     /* Handle describing change and conflict */
+  ),
+  void *pCtx                      /* First argument passed to xConflict */
 );
 SQLITE_API int sqlite3changeset_apply_v2_strm(
-    sqlite3 *db, /* Apply change to "main" db of this handle */
-    int (*xInput)(void *pIn, void *pData, int *pnData), /* Input function */
-    void *pIn,                      /* First arg for xInput */
-    int (*xFilter)(void *pCtx,      /* Copy of sixth arg to _apply() */
-                   const char *zTab /* Table name */
-                   ),
-    int (*xConflict)(
-        void *pCtx,               /* Copy of sixth arg to _apply() */
-        int eConflict,            /* DATA, MISSING, CONFLICT, CONSTRAINT */
-        sqlite3_changeset_iter *p /* Handle describing change and conflict */
-        ),
-    void *pCtx, /* First argument passed to xConflict */
-    void **ppRebase, int *pnRebase, int flags);
+  sqlite3 *db,                    /* Apply change to "main" db of this handle */
+  int (*xInput)(void *pIn, void *pData, int *pnData), /* Input function */
+  void *pIn,                                          /* First arg for xInput */
+  int(*xFilter)(
+    void *pCtx,                   /* Copy of sixth arg to _apply() */
+    const char *zTab              /* Table name */
+  ),
+  int(*xConflict)(
+    void *pCtx,                   /* Copy of sixth arg to _apply() */
+    int eConflict,                /* DATA, MISSING, CONFLICT, CONSTRAINT */
+    sqlite3_changeset_iter *p     /* Handle describing change and conflict */
+  ),
+  void *pCtx,                     /* First argument passed to xConflict */
+  void **ppRebase, int *pnRebase,
+  int flags
+);
 SQLITE_API int sqlite3changeset_concat_strm(
-    int (*xInputA)(void *pIn, void *pData, int *pnData), void *pInA,
-    int (*xInputB)(void *pIn, void *pData, int *pnData), void *pInB,
-    int (*xOutput)(void *pOut, const void *pData, int nData), void *pOut);
+  int (*xInputA)(void *pIn, void *pData, int *pnData),
+  void *pInA,
+  int (*xInputB)(void *pIn, void *pData, int *pnData),
+  void *pInB,
+  int (*xOutput)(void *pOut, const void *pData, int nData),
+  void *pOut
+);
 SQLITE_API int sqlite3changeset_invert_strm(
-    int (*xInput)(void *pIn, void *pData, int *pnData), void *pIn,
-    int (*xOutput)(void *pOut, const void *pData, int nData), void *pOut);
-SQLITE_API int sqlite3changeset_start_strm(sqlite3_changeset_iter **pp,
-                                           int (*xInput)(void *pIn, void *pData,
-                                                         int *pnData),
-                                           void *pIn);
+  int (*xInput)(void *pIn, void *pData, int *pnData),
+  void *pIn,
+  int (*xOutput)(void *pOut, const void *pData, int nData),
+  void *pOut
+);
+SQLITE_API int sqlite3changeset_start_strm(
+  sqlite3_changeset_iter **pp,
+  int (*xInput)(void *pIn, void *pData, int *pnData),
+  void *pIn
+);
 SQLITE_API int sqlite3changeset_start_v2_strm(
-    sqlite3_changeset_iter **pp,
-    int (*xInput)(void *pIn, void *pData, int *pnData), void *pIn, int flags);
+  sqlite3_changeset_iter **pp,
+  int (*xInput)(void *pIn, void *pData, int *pnData),
+  void *pIn,
+  int flags
+);
 SQLITE_API int sqlite3session_changeset_strm(
-    sqlite3_session *pSession,
-    int (*xOutput)(void *pOut, const void *pData, int nData), void *pOut);
+  sqlite3_session *pSession,
+  int (*xOutput)(void *pOut, const void *pData, int nData),
+  void *pOut
+);
 SQLITE_API int sqlite3session_patchset_strm(
-    sqlite3_session *pSession,
-    int (*xOutput)(void *pOut, const void *pData, int nData), void *pOut);
-SQLITE_API int sqlite3changegroup_add_strm(sqlite3_changegroup *,
-                                           int (*xInput)(void *pIn, void *pData,
-                                                         int *pnData),
-                                           void *pIn);
-SQLITE_API int sqlite3changegroup_output_strm(
-    sqlite3_changegroup *,
-    int (*xOutput)(void *pOut, const void *pData, int nData), void *pOut);
+  sqlite3_session *pSession,
+  int (*xOutput)(void *pOut, const void *pData, int nData),
+  void *pOut
+);
+SQLITE_API int sqlite3changegroup_add_strm(sqlite3_changegroup*,
+    int (*xInput)(void *pIn, void *pData, int *pnData),
+    void *pIn
+);
+SQLITE_API int sqlite3changegroup_output_strm(sqlite3_changegroup*,
+    int (*xOutput)(void *pOut, const void *pData, int nData),
+    void *pOut
+);
 SQLITE_API int sqlite3rebaser_rebase_strm(
-    sqlite3_rebaser *pRebaser,
-    int (*xInput)(void *pIn, void *pData, int *pnData), void *pIn,
-    int (*xOutput)(void *pOut, const void *pData, int nData), void *pOut);
+  sqlite3_rebaser *pRebaser,
+  int (*xInput)(void *pIn, void *pData, int *pnData),
+  void *pIn,
+  int (*xOutput)(void *pOut, const void *pData, int nData),
+  void *pOut
+);
 
 /*
 ** CAPI3REF: Configure global parameters
@@ -12596,7 +12723,7 @@ SQLITE_API int sqlite3session_config(int op, void *pArg);
 }
 #endif
 
-#endif /* !defined(__SQLITESESSION_H_) && defined(SQLITE_ENABLE_SESSION) */
+#endif  /* !defined(__SQLITESESSION_H_) && defined(SQLITE_ENABLE_SESSION) */
 
 /******** End of sqlite3session.h *********/
 /******** Begin file fts5.h *********/
@@ -12619,8 +12746,10 @@ SQLITE_API int sqlite3session_config(int op, void *pArg);
 **     * custom auxiliary functions.
 */
 
+
 #ifndef _FTS5_H
 #define _FTS5_H
+
 
 #ifdef __cplusplus
 extern "C" {
@@ -12638,11 +12767,11 @@ typedef struct Fts5Context Fts5Context;
 typedef struct Fts5PhraseIter Fts5PhraseIter;
 
 typedef void (*fts5_extension_function)(
-    const Fts5ExtensionApi *pApi, /* API offered by current FTS version */
-    Fts5Context *pFts,            /* First arg to pass to pApi functions */
-    sqlite3_context *pCtx,        /* Context for returning result/error */
-    int nVal,                     /* Number of values in apVal[] array */
-    sqlite3_value **apVal         /* Array of trailing arguments */
+  const Fts5ExtensionApi *pApi,   /* API offered by current FTS version */
+  Fts5Context *pFts,              /* First arg to pass to pApi functions */
+  sqlite3_context *pCtx,          /* Context for returning result/error */
+  int nVal,                       /* Number of values in apVal[] array */
+  sqlite3_value **apVal           /* Array of trailing arguments */
 );
 
 struct Fts5PhraseIter {
@@ -12687,8 +12816,11 @@ struct Fts5PhraseIter {
 **   created with the "columnsize=0" option.
 **
 ** xColumnText:
-**   This function attempts to retrieve the text of column iCol of the
-**   current document. If successful, (*pz) is set to point to a buffer
+**   If parameter iCol is less than zero, or greater than or equal to the
+**   number of columns in the table, SQLITE_RANGE is returned.
+**
+**   Otherwise, this function attempts to retrieve the text of column iCol of
+**   the current document. If successful, (*pz) is set to point to a buffer
 **   containing the text in utf-8 encoding, (*pn) is set to the size in bytes
 **   (not characters) of the buffer and SQLITE_OK is returned. Otherwise,
 **   if an error occurs, an SQLite error code is returned and the final values
@@ -12698,8 +12830,10 @@ struct Fts5PhraseIter {
 **   Returns the number of phrases in the current query expression.
 **
 ** xPhraseSize:
-**   Returns the number of tokens in phrase iPhrase of the query. Phrases
-**   are numbered starting from zero.
+**   If parameter iCol is less than zero, or greater than or equal to the
+**   number of phrases in the current query, as returned by xPhraseCount,
+**   0 is returned. Otherwise, this function returns the number of tokens in
+**   phrase iPhrase of the query. Phrases are numbered starting from zero.
 **
 ** xInstCount:
 **   Set *pnInst to the total number of occurrences of all phrases within
@@ -12715,12 +12849,13 @@ struct Fts5PhraseIter {
 **   Query for the details of phrase match iIdx within the current row.
 **   Phrase matches are numbered starting from zero, so the iIdx argument
 **   should be greater than or equal to zero and smaller than the value
-**   output by xInstCount().
+**   output by xInstCount(). If iIdx is less than zero or greater than
+**   or equal to the value returned by xInstCount(), SQLITE_RANGE is returned.
 **
-**   Usually, output parameter *piPhrase is set to the phrase number, *piCol
+**   Otherwise, output parameter *piPhrase is set to the phrase number, *piCol
 **   to the column in which it occurs and *piOff the token offset of the
-**   first token of the phrase. Returns SQLITE_OK if successful, or an error
-**   code (i.e. SQLITE_NOMEM) if an error occurs.
+**   first token of the phrase. SQLITE_OK is returned if successful, or an
+**   error code (i.e. SQLITE_NOMEM) if an error occurs.
 **
 **   This API can be quite slow if used with an FTS5 table created with the
 **   "detail=none" or "detail=column" option.
@@ -12745,6 +12880,10 @@ struct Fts5PhraseIter {
 **   function may be used to access the properties of each matched row.
 **   Invoking Api.xUserData() returns a copy of the pointer passed as
 **   the third argument to pUserData.
+**
+**   If parameter iPhrase is less than zero, or greater than or equal to
+**   the number of phrases in the query, as returned by xPhraseCount(),
+**   this function returns SQLITE_RANGE.
 **
 **   If the callback function returns any value other than SQLITE_OK, the
 **   query is abandoned and the xQueryPhrase function returns immediately.
@@ -12860,45 +12999,83 @@ struct Fts5PhraseIter {
 **
 ** xPhraseNextColumn()
 **   See xPhraseFirstColumn above.
+**
+** xQueryToken(pFts5, iPhrase, iToken, ppToken, pnToken)
+**   This is used to access token iToken of phrase iPhrase of the current
+**   query. Before returning, output parameter *ppToken is set to point
+**   to a buffer containing the requested token, and *pnToken to the
+**   size of this buffer in bytes.
+**
+**   If iPhrase or iToken are less than zero, or if iPhrase is greater than
+**   or equal to the number of phrases in the query as reported by
+**   xPhraseCount(), or if iToken is equal to or greater than the number of
+**   tokens in the phrase, SQLITE_RANGE is returned and *ppToken and *pnToken
+     are both zeroed.
+**
+**   The output text is not a copy of the query text that specified the
+**   token. It is the output of the tokenizer module. For tokendata=1
+**   tables, this includes any embedded 0x00 and trailing data.
+**
+** xInstToken(pFts5, iIdx, iToken, ppToken, pnToken)
+**   This is used to access token iToken of phrase hit iIdx within the
+**   current row. If iIdx is less than zero or greater than or equal to the
+**   value returned by xInstCount(), SQLITE_RANGE is returned.  Otherwise,
+**   output variable (*ppToken) is set to point to a buffer containing the
+**   matching document token, and (*pnToken) to the size of that buffer in
+**   bytes. This API is not available if the specified token matches a
+**   prefix query term. In that case both output variables are always set
+**   to 0.
+**
+**   The output text is not a copy of the document text that was tokenized.
+**   It is the output of the tokenizer module. For tokendata=1 tables, this
+**   includes any embedded 0x00 and trailing data.
+**
+**   This API can be quite slow if used with an FTS5 table created with the
+**   "detail=none" or "detail=column" option.
 */
 struct Fts5ExtensionApi {
-  int iVersion; /* Currently always set to 2 */
+  int iVersion;                   /* Currently always set to 3 */
 
-  void *(*xUserData)(Fts5Context *);
+  void *(*xUserData)(Fts5Context*);
 
-  int (*xColumnCount)(Fts5Context *);
-  int (*xRowCount)(Fts5Context *, sqlite3_int64 *pnRow);
-  int (*xColumnTotalSize)(Fts5Context *, int iCol, sqlite3_int64 *pnToken);
+  int (*xColumnCount)(Fts5Context*);
+  int (*xRowCount)(Fts5Context*, sqlite3_int64 *pnRow);
+  int (*xColumnTotalSize)(Fts5Context*, int iCol, sqlite3_int64 *pnToken);
 
-  int (*xTokenize)(Fts5Context *, const char *pText,
-                   int nText,  /* Text to tokenize */
-                   void *pCtx, /* Context passed to xToken() */
-                   int (*xToken)(void *, int, const char *, int, int,
-                                 int) /* Callback */
+  int (*xTokenize)(Fts5Context*,
+    const char *pText, int nText, /* Text to tokenize */
+    void *pCtx,                   /* Context passed to xToken() */
+    int (*xToken)(void*, int, const char*, int, int, int)       /* Callback */
   );
 
-  int (*xPhraseCount)(Fts5Context *);
-  int (*xPhraseSize)(Fts5Context *, int iPhrase);
+  int (*xPhraseCount)(Fts5Context*);
+  int (*xPhraseSize)(Fts5Context*, int iPhrase);
 
-  int (*xInstCount)(Fts5Context *, int *pnInst);
-  int (*xInst)(Fts5Context *, int iIdx, int *piPhrase, int *piCol, int *piOff);
+  int (*xInstCount)(Fts5Context*, int *pnInst);
+  int (*xInst)(Fts5Context*, int iIdx, int *piPhrase, int *piCol, int *piOff);
 
-  sqlite3_int64 (*xRowid)(Fts5Context *);
-  int (*xColumnText)(Fts5Context *, int iCol, const char **pz, int *pn);
-  int (*xColumnSize)(Fts5Context *, int iCol, int *pnToken);
+  sqlite3_int64 (*xRowid)(Fts5Context*);
+  int (*xColumnText)(Fts5Context*, int iCol, const char **pz, int *pn);
+  int (*xColumnSize)(Fts5Context*, int iCol, int *pnToken);
 
-  int (*xQueryPhrase)(Fts5Context *, int iPhrase, void *pUserData,
-                      int (*)(const Fts5ExtensionApi *, Fts5Context *, void *));
-  int (*xSetAuxdata)(Fts5Context *, void *pAux, void (*xDelete)(void *));
-  void *(*xGetAuxdata)(Fts5Context *, int bClear);
+  int (*xQueryPhrase)(Fts5Context*, int iPhrase, void *pUserData,
+    int(*)(const Fts5ExtensionApi*,Fts5Context*,void*)
+  );
+  int (*xSetAuxdata)(Fts5Context*, void *pAux, void(*xDelete)(void*));
+  void *(*xGetAuxdata)(Fts5Context*, int bClear);
 
-  int (*xPhraseFirst)(Fts5Context *, int iPhrase, Fts5PhraseIter *, int *,
-                      int *);
-  void (*xPhraseNext)(Fts5Context *, Fts5PhraseIter *, int *piCol, int *piOff);
+  int (*xPhraseFirst)(Fts5Context*, int iPhrase, Fts5PhraseIter*, int*, int*);
+  void (*xPhraseNext)(Fts5Context*, Fts5PhraseIter*, int *piCol, int *piOff);
 
-  int (*xPhraseFirstColumn)(Fts5Context *, int iPhrase, Fts5PhraseIter *,
-                            int *);
-  void (*xPhraseNextColumn)(Fts5Context *, Fts5PhraseIter *, int *piCol);
+  int (*xPhraseFirstColumn)(Fts5Context*, int iPhrase, Fts5PhraseIter*, int*);
+  void (*xPhraseNextColumn)(Fts5Context*, Fts5PhraseIter*, int *piCol);
+
+  /* Below this point are iVersion>=3 only */
+  int (*xQueryToken)(Fts5Context*,
+      int iPhrase, int iToken,
+      const char **ppToken, int *pnToken
+  );
+  int (*xInstToken)(Fts5Context*, int iIdx, int iToken, const char**, int*);
 };
 
 /*
@@ -13100,30 +13277,32 @@ struct Fts5ExtensionApi {
 typedef struct Fts5Tokenizer Fts5Tokenizer;
 typedef struct fts5_tokenizer fts5_tokenizer;
 struct fts5_tokenizer {
-  int (*xCreate)(void *, const char **azArg, int nArg, Fts5Tokenizer **ppOut);
-  void (*xDelete)(Fts5Tokenizer *);
-  int (*xTokenize)(
-      Fts5Tokenizer *, void *pCtx,
-      int flags, /* Mask of FTS5_TOKENIZE_* flags */
+  int (*xCreate)(void*, const char **azArg, int nArg, Fts5Tokenizer **ppOut);
+  void (*xDelete)(Fts5Tokenizer*);
+  int (*xTokenize)(Fts5Tokenizer*,
+      void *pCtx,
+      int flags,            /* Mask of FTS5_TOKENIZE_* flags */
       const char *pText, int nText,
-      int (*xToken)(void *pCtx, /* Copy of 2nd argument to xTokenize() */
-                    int tflags, /* Mask of FTS5_TOKEN_* flags */
-                    const char *pToken, /* Pointer to buffer containing token */
-                    int nToken,         /* Size of token in bytes */
-                    int iStart, /* Byte offset of token within input text */
-                    int iEnd /* Byte offset of end of token within input text */
-                    ));
+      int (*xToken)(
+        void *pCtx,         /* Copy of 2nd argument to xTokenize() */
+        int tflags,         /* Mask of FTS5_TOKEN_* flags */
+        const char *pToken, /* Pointer to buffer containing token */
+        int nToken,         /* Size of token in bytes */
+        int iStart,         /* Byte offset of token within input text */
+        int iEnd            /* Byte offset of end of token within input text */
+      )
+  );
 };
 
 /* Flags that may be passed as the third argument to xTokenize() */
-#define FTS5_TOKENIZE_QUERY 0x0001
-#define FTS5_TOKENIZE_PREFIX 0x0002
-#define FTS5_TOKENIZE_DOCUMENT 0x0004
-#define FTS5_TOKENIZE_AUX 0x0008
+#define FTS5_TOKENIZE_QUERY     0x0001
+#define FTS5_TOKENIZE_PREFIX    0x0002
+#define FTS5_TOKENIZE_DOCUMENT  0x0004
+#define FTS5_TOKENIZE_AUX       0x0008
 
 /* Flags that may be passed by the tokenizer implementation back to FTS5
 ** as the third argument to the supplied xToken callback. */
-#define FTS5_TOKEN_COLOCATED 0x0001 /* Same position as prev. token */
+#define FTS5_TOKEN_COLOCATED    0x0001      /* Same position as prev. token */
 
 /*
 ** END OF CUSTOM TOKENIZERS
@@ -13134,20 +13313,33 @@ struct fts5_tokenizer {
 */
 typedef struct fts5_api fts5_api;
 struct fts5_api {
-  int iVersion; /* Currently always set to 2 */
+  int iVersion;                   /* Currently always set to 2 */
 
   /* Create a new tokenizer */
-  int (*xCreateTokenizer)(fts5_api *pApi, const char *zName, void *pUserData,
-                          fts5_tokenizer *pTokenizer, void (*xDestroy)(void *));
+  int (*xCreateTokenizer)(
+    fts5_api *pApi,
+    const char *zName,
+    void *pUserData,
+    fts5_tokenizer *pTokenizer,
+    void (*xDestroy)(void*)
+  );
 
   /* Find an existing tokenizer */
-  int (*xFindTokenizer)(fts5_api *pApi, const char *zName, void **ppUserData,
-                        fts5_tokenizer *pTokenizer);
+  int (*xFindTokenizer)(
+    fts5_api *pApi,
+    const char *zName,
+    void **ppUserData,
+    fts5_tokenizer *pTokenizer
+  );
 
   /* Create a new auxiliary function */
-  int (*xCreateFunction)(fts5_api *pApi, const char *zName, void *pUserData,
-                         fts5_extension_function xFunction,
-                         void (*xDestroy)(void *));
+  int (*xCreateFunction)(
+    fts5_api *pApi,
+    const char *zName,
+    void *pUserData,
+    fts5_extension_function xFunction,
+    void (*xDestroy)(void*)
+  );
 };
 
 /*
@@ -13155,7 +13347,7 @@ struct fts5_api {
 *************************************************************************/
 
 #ifdef __cplusplus
-} /* end of the 'extern "C"' block */
+}  /* end of the 'extern "C"' block */
 #endif
 
 #endif /* _FTS5_H */


### PR DESCRIPTION
SQLite 3.45 brings the JSONB storage format, that allows SQLIte to store and handle its internal JSON implementation in any a blob column to avoid the overhead of parsing JSON text.

More at: https://sqlite.org/releaselog/3_45_1.html