### PR TITLE
Use of prepared statements in batch operations

### DIFF
--- a/cpp/bridge.cpp
+++ b/cpp/bridge.cpp
@@ -192,6 +192,8 @@ BridgeResult opsqlite_execute_prepared_statement(
     check_db_open(dbName);
     sqlite3 *db = dbMap[dbName];
 
+    sqlite3_reset(statement);
+
     return opsqlite_execute_prepared_statement(db, statement, results, metadatas);
 }
 
@@ -199,8 +201,6 @@ BridgeResult opsqlite_execute_prepared_statement(
     sqlite3 *db, sqlite3_stmt *statement,
     std::vector<DumbHostObject> *results,
     std::shared_ptr<std::vector<SmartHostObject>> metadatas) {
-
-  sqlite3_reset(statement);
 
   const char *errorMessage;
 

--- a/cpp/bridge.h
+++ b/cpp/bridge.h
@@ -21,6 +21,7 @@ typedef std::function<void(std::string dbName)> RollbackCallback;
 
 BridgeResult opsqlite_open(std::string const &dbName,
                            std::string const &dbPath);
+sqlite3 *opsqlite_get_connection(std::string const &dbName);
 
 BridgeResult opsqlite_close(std::string const &dbName);
 
@@ -46,6 +47,9 @@ BridgeResult opsqlite_execute_raw(std::string const &dbName,
                                   const std::vector<JSVariant> *params,
                                   std::vector<std::vector<JSVariant>> *results);
 
+BridgeResult opsqlite_execute_literal(sqlite3 *db,
+                                      std::string const &query);
+
 BridgeResult opsqlite_execute_literal(std::string const &dbName,
                                       std::string const &query);
 
@@ -63,12 +67,20 @@ BridgeResult opsqlite_deregister_rollback_hook(std::string const &dbName);
 
 sqlite3_stmt *opsqlite_prepare_statement(std::string const &dbName,
                                          std::string const &query);
+sqlite3_stmt *opsqlite_prepare_statement(sqlite3 *connection,
+                                         std::string const &query);
+
 
 void opsqlite_bind_statement(sqlite3_stmt *statement,
                              const std::vector<JSVariant> *params);
 
 BridgeResult opsqlite_execute_prepared_statement(
     std::string const &dbName, sqlite3_stmt *statement,
+    std::vector<DumbHostObject> *results,
+    std::shared_ptr<std::vector<SmartHostObject>> metadatas);
+
+BridgeResult opsqlite_execute_prepared_statement(
+    sqlite3 *connection, sqlite3_stmt *statement,
     std::vector<DumbHostObject> *results,
     std::shared_ptr<std::vector<SmartHostObject>> metadatas);
 

--- a/cpp/sqlbatchexecutor.h
+++ b/cpp/sqlbatchexecutor.h
@@ -9,9 +9,11 @@ namespace opsqlite {
 
 namespace jsi = facebook::jsi;
 
+using BatchParams = std::variant<std::vector<JSVariant>, std::vector<std::vector<JSVariant>>>;
+
 struct BatchArguments {
   std::string sql;
-  std::shared_ptr<std::vector<JSVariant>> params;
+  std::shared_ptr<BatchParams> params;
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@op-engineering/op-sqlite",
-  "version": "2.0.18",
+  "version": "2.0.19",
   "description": "Next generation SQLite for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
Modified batch executors (ExecuteSqlBatch) to reuse prepared statements.
From the begining of the API, SQL Batches supports SQL parameters as an Array of objects, or a array of arrays.
So, you can use the API like:

```
const sql = 'insert into some_table (col1, col2) values (?, ?)'
const params1 = [1, 2];
const params2 = [1, 2];

db.executeBatch([sql, params1]);
db.executeBatch([sql, params2]);
```

Or, you can dispatch a single time:
```
const sql = 'insert into some_table (col1, col2) values (?, ?)'
const params1 = [1, 2];
const params2 = [1, 2];
const params = [params1, params2]

db.executeBatch([sql, params]);
```

When running in the second form, the driver will reuse prepared statments to reduce the overhead of preparing  the same query multiples times. The statments will be reused and rebinded with new parameters.

Also, new overloaded methods were added to the bridge to check and collect database instance pointers to use this reference instead of database name in some operations, avoiding multiple database checks and map access in batch operations.