### PR TITLE
Fix missing gradle properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,4 +74,3 @@ android/.cxx
 lib/
 # Gradle
 android/gradle/
-android/gradle*

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,1 @@
+OPSQLite_kotlinVersion=1.8.0


### PR DESCRIPTION
Seems I botched the gitignore at some point, ignoring an important configuration file. If the host app does not have kotlin as a dependency it will fail to install.

This re-adds the gradle.properties into the checked repo and fixes https://github.com/OP-Engineering/op-sqlite/issues/56