### PR TITLE
New configuration parsing from package.json

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -43,7 +43,7 @@ if (OP_SQLITE_USE_SQLCIPHER)
   target_sources(${PACKAGE_NAME} PRIVATE ../cpp/sqlcipher/sqlite3.h ../cpp/sqlcipher/sqlite3.c)
 
   add_definitions(
-    -DOP_SQLITE_USE_SQLCIPHER
+    -DOP_SQLITE_USE_SQLCIPHER=1
     -DSQLITE_HAS_CODEC
     -DSQLITE_TEMP_STORE=2
   )
@@ -55,7 +55,7 @@ endif()
 
 if (OP_SQLITE_USE_CRSQLITE)
   add_definitions(
-    -DOP_SQLITE_USE_CRSQLITE
+    -DOP_SQLITE_USE_CRSQLITE=1
   )
 endif()
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -100,7 +100,7 @@ android {
   }
 
   defaultConfig {
-    minSdkVersion 23 
+    minSdkVersion 21
     targetSdkVersion safeExtGet('targetSdkVersion', 34)
     versionCode 1
     versionName "1.0"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,5 @@
 import java.nio.file.Paths
+import groovy.json.JsonSlurper
 
 buildscript {
   repositories {
@@ -26,7 +27,39 @@ def isNewArchitectureEnabled() {
   return project.hasProperty("newArchEnabled") && project.newArchEnabled == "true"
 }
 
-def SQLITE_FLAGS = rootProject.properties['OPSQLiteFlags']
+def useSQLCipher = false
+def useCRSQLite = false
+def performanceMode = "0"
+def sqliteFlags = ""
+
+def packageJsonFile = new File("$rootDir/../package.json")
+def packageJson = new JsonSlurper().parseText(packageJsonFile.text)
+
+def opsqliteConfig = packageJson["op-sqlite"]
+if(opsqliteConfig) {
+  useSQLCipher = opsqliteConfig["sqlcipher"]
+  useCRSQLite = opsqliteConfig["crsqlite"]
+  performanceMode = opsqliteConfig["performanceMode"] ? opsqliteConfig["performanceMode"] : ""
+  sqliteFlags = opsqliteConfig["sqliteFlags"] ? opsqliteConfig["sqliteFlags"] : ""
+}
+
+if(useSQLCipher) {
+  println "[OP-SQLITE] using SQLCipher 🔒"
+} else {
+  println "[OP-SQLITE] using Vanilla SQLite"
+}
+
+if(useCRSQLite) {
+  println "[OP-SQLITE] using CR-SQLite 🤖"
+}
+
+if(performanceMode == "1") {
+  println "[OP-SQLITE] Thread unsafe performance mode enabled. Use only transactions! 🚀"
+}
+
+if(performanceMode == "2") {
+  println "[OP-SQLITE] Thread safe performance mode enabled! 🚀"
+}
 
 if (isNewArchitectureEnabled()) {
     apply plugin: "com.facebook.react"
@@ -47,8 +80,6 @@ def reactNativeArchitectures() {
 def getExtOrDefault(name) {
   return rootProject.ext.has(name) ? rootProject.ext.get(name) : project.properties["OPSQLite" + name]
 }
-
-def USE_HERMES = rootProject.ext.hermesEnabled
 
 android {
   
@@ -76,31 +107,19 @@ android {
     
     externalNativeBuild {
         cmake {
-            if(System.getenv("OP_SQLITE_PERF") == '1') {
-              println "OP-SQLITE performance mode enabled! 🚀"
+            if(performanceMode == '1') {
               cFlags  += ["-DSQLITE_DQS=0", "-DSQLITE_THREADSAFE=0", "-DSQLITE_DEFAULT_MEMSTATUS=0", "-DSQLITE_DEFAULT_WAL_SYNCHRONOUS=1", "-DSQLITE_LIKE_DOESNT_MATCH_BLOBS=1", "-DSQLITE_MAX_EXPR_DEPTH=0", "-DSQLITE_OMIT_DEPRECATED=1", "-DSQLITE_OMIT_PROGRESS_CALLBACK=1", "-DSQLITE_OMIT_SHARED_CACHE=1", "-DSQLITE_USE_ALLOCA=1"]
             }
-            if(System.getenv("OP_SQLITE_PERF") == '2') {
-              println "OP-SQLITE (thread safe) performance mode enabled! 🚀"
+            if(performanceMode == '2') {
               cFlags += ["-DSQLITE_DQS=0", "-DSQLITE_THREADSAFE=1", "-DSQLITE_DEFAULT_MEMSTATUS=0", "-DSQLITE_DEFAULT_WAL_SYNCHRONOUS=1", "-DSQLITE_LIKE_DOESNT_MATCH_BLOBS=1", "-DSQLITE_MAX_EXPR_DEPTH=0", "-DSQLITE_OMIT_DEPRECATED=1", "-DSQLITE_OMIT_PROGRESS_CALLBACK=1", "-DSQLITE_OMIT_SHARED_CACHE=1", "-DSQLITE_USE_ALLOCA=1"]
-            }
-
-            if(System.getenv("OP_SQLITE_USE_SQLCIPHER") == '1') {
-              println "OP-SQLITE using SQLCipher! 🔒"
-              cppFlags += "-DOP_SQLITE_USE_SQLCIPHER=1"
-            }
-
-            if(System.getenv("OP_SQLITE_USE_CRSQLITE") == '1') {
-              println "OP-SQLITE using CR-SQLite! 🤖"
-              cppFlags += "-DOP_SQLITE_USE_CRSQLITE=1"
             }
 
             cppFlags "-O2", "-fexceptions", "-frtti", "-std=c++1y", "-DONANDROID"
             abiFilters 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'
             arguments "-DANDROID_STL=c++_shared",
-              "-DSQLITE_FLAGS='${SQLITE_FLAGS ? SQLITE_FLAGS : ''}'"
-              "-DOP_SQLITE_USE_SQLCIPHER='${System.getenv("OP_SQLITE_USE_SQLCIPHER") == '1'? 1 : 0}'"
-              "-DOP_SQLITE_USE_CRSQLITE='${System.getenv("OP_SQLITE_USE_CRSQLITE") == '1'? 1 : 0}'"
+              "-DSQLITE_FLAGS='$sqliteFlags'"
+              "-DOP_SQLITE_USE_SQLCIPHER='${useSQLCipher? 1 : 0}'"
+              "-DOP_SQLITE_USE_CRSQLITE='${useCRSQLite? 1 : 0}'"
             abiFilters (*reactNativeArchitectures())
         }
     }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -8,11 +8,9 @@ PODS:
     - hermes-engine/Pre-built (= 0.74.0-rc.6)
   - hermes-engine/Pre-built (0.74.0-rc.6)
   - op-sqlite (4.0.1):
-    - OpenSSL-Universal
     - React
     - React-callinvoker
     - React-Core
-  - OpenSSL-Universal (3.1.5001)
   - RCT-Folly (2024.01.01.00):
     - boost
     - DoubleConversion
@@ -1236,7 +1234,6 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
-    - OpenSSL-Universal
     - SocketRocket
 
 EXTERNAL SOURCES:
@@ -1361,8 +1358,7 @@ SPEC CHECKSUMS:
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   hermes-engine: 1a846a8f620a08c60f5f89aa65b8664f769f742f
-  op-sqlite: db0f4b35d0966f75b5722f1b42315faa7d1b78e2
-  OpenSSL-Universal: 29a9c9d4baf23f5fcd1294b657e4cc275e605bc3
+  op-sqlite: e37a97e50884808f174723fdd92a6051be1babfa
   RCT-Folly: 045d6ecaa59d826c5736dfba0b2f4083ff8d79df
   RCTDeprecation: 82b53c4f460b7a5b27c6be8310a71bc84df583f5
   RCTRequired: d1a99a9f78fcc4acca99ab397822f4e58601b134

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -8,9 +8,11 @@ PODS:
     - hermes-engine/Pre-built (= 0.74.0-rc.6)
   - hermes-engine/Pre-built (0.74.0-rc.6)
   - op-sqlite (4.0.1):
+    - OpenSSL-Universal
     - React
     - React-callinvoker
     - React-Core
+  - OpenSSL-Universal (3.1.5001)
   - RCT-Folly (2024.01.01.00):
     - boost
     - DoubleConversion
@@ -1234,6 +1236,7 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
+    - OpenSSL-Universal
     - SocketRocket
 
 EXTERNAL SOURCES:
@@ -1358,7 +1361,8 @@ SPEC CHECKSUMS:
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   hermes-engine: 1a846a8f620a08c60f5f89aa65b8664f769f742f
-  op-sqlite: e37a97e50884808f174723fdd92a6051be1babfa
+  op-sqlite: bee4f4e1695d2af485ce2937862ed742d4368833
+  OpenSSL-Universal: 29a9c9d4baf23f5fcd1294b657e4cc275e605bc3
   RCT-Folly: 045d6ecaa59d826c5736dfba0b2f4083ff8d79df
   RCTDeprecation: 82b53c4f460b7a5b27c6be8310a71bc84df583f5
   RCTRequired: d1a99a9f78fcc4acca99ab397822f4e58601b134

--- a/example/package.json
+++ b/example/package.json
@@ -54,5 +54,10 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "op-sqlite": {
+    "sqlcipher": false,
+    "crsqlite": false,
+    "performance_mode": "1"
   }
 }

--- a/example/package.json
+++ b/example/package.json
@@ -56,8 +56,10 @@
     "node": ">=18"
   },
   "op-sqlite": {
-    "sqlcipher": false,
-    "crsqlite": false,
-    "performance_mode": "1"
+    "sqlcipher": true,
+    "crsqlite": true,
+    "performanceMode": "1",
+    "iosSqlite": false,
+    "sqliteFlags": "-DSQLITE_DQS=0"
   }
 }

--- a/example/src/tests/queries.spec.ts
+++ b/example/src/tests/queries.spec.ts
@@ -34,10 +34,10 @@ export function queriesTests() {
   });
 
   describe('Queries tests', () => {
-    it('Test crsqlite', async () => {
-      const res = db.execute('select crsql_as_crr("User")');
-      console.warn(res);
-    });
+    // it('Test crsqlite', async () => {
+    //   const res = db.execute('select crsql_as_crr("User")');
+    //   console.warn(res);
+    // });
 
     it('Insert', async () => {
       const id = chance.integer();
@@ -789,6 +789,19 @@ export function queriesTests() {
         'SELECT id, name, age, networth FROM User',
       );
       expect(res).to.eql([[id, name, age, networth]]);
+    });
+
+    it('Create fts5 virtual table', async () => {
+      db.execute('CREATE VIRTUAL TABLE fts5_table USING fts5(name, content);');
+      db.execute('INSERT INTO fts5_table (name, content) VALUES(?, ?)', [
+        'test',
+        'test content',
+      ]);
+
+      const res = db.execute('SELECT * FROM fts5_table');
+      expect(res.rows?._array).to.eql([
+        {name: 'test', content: 'test content'},
+      ]);
     });
   });
 }

--- a/ios/OPSQLite.mm
+++ b/ios/OPSQLite.mm
@@ -78,6 +78,10 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install) {
   NSBundle *bundle = [NSBundle bundleWithIdentifier:@"io.vlcn.crsqlite"];
   NSString *crsqlitePath = [bundle pathForResource:@"crsqlite" ofType:@""];
 
+  if (crsqlitePath == nil) {
+    crsqlitePath = @"";
+  }
+
   opsqlite::install(runtime, callInvoker, [documentPath UTF8String],
                     [crsqlitePath UTF8String]);
   return @true;

--- a/op-sqlite.podspec
+++ b/op-sqlite.podspec
@@ -12,10 +12,10 @@ parent_folder_name = File.basename(__dir__)
 app_package = nil
 # for development purposes on user machines the podspec should be able to read the package.json from the root folder
 # since it lives inside node_modules/@op-engineering/op-sqlite
-if parent_folder_name == "op-sqlite"
-  app_package = JSON.parse(File.read(File.join(__dir__, "example", "package.json")))
+if __dir__.include?("node_modules")
+  app_package = JSON.parse(File.read(File.join(__dir__, "..", "..", "..", "package.json")))
 else
-  app_package = JSON.parse(File.read(File.join(__dir__, "..", "..", "package.json")))
+  app_package = JSON.parse(File.read(File.join(__dir__, "example", "package.json")))
 end
 
 op_sqlite_config = app_package["op-sqlite"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@op-engineering/op-sqlite",
-  "version": "4.0.1",
+  "version": "5.0.0",
   "description": "Next generation SQLite for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Next generation SQLite for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
-  "types": "lib/typescript/index.d.ts",
+  "types": "lib/typescript/src/index.d.ts",
   "react-native": "src/index",
   "source": "src/index",
   "files": [


### PR DESCRIPTION
Instead of reading environment variables the configuration now needs to be declared in the package.json:

```
"op-sqlite": {
  "sqlcipher": true,
  "crsqlite": true,
  "performanceMode": "1",
  "iosSqlite": false,
  "sqliteFlags": "-DSQLITE_DQS=0"
}
```

This lead to more reproducible builds