### PR TITLE
[ios] moveAssetsDatabase | Add support for path

### DIFF
--- a/ios/OPSQLite.mm
+++ b/ios/OPSQLite.mm
@@ -94,10 +94,15 @@ RCT_EXPORT_METHOD(moveAssetsDatabase
   NSString *documentPath = [NSSearchPathForDirectoriesInDomains(
       NSLibraryDirectory, NSUserDomainMask, true) objectAtIndex:0];
 
+  NSString *path = args[@"path"];
   NSString *filename = args[@"filename"];
   BOOL overwrite = args[@"overwrite"];
 
-  NSString *sourcePath = [[NSBundle mainBundle] pathForResource:filename
+  NSString *sourcePath = path
+                          ? [[NSBundle mainBundle] pathForResource:filename
+                                                         ofType:nil
+                                                         inDirectory:path]
+                          : [[NSBundle mainBundle] pathForResource:filename
                                                          ofType:nil];
 
   NSString *destinationPath =


### PR DESCRIPTION
We have a case where we use `.bundle` to "load" all the files in the folder; we utilize `IOSConfig.XcodeUtils.addResourceFileToGroup` to do this

And at the moment it's done the same way with Android as well, using `android.sourceSets`

Basically the tree is
```
at `./`
        -> db.bundle/
                - main.db
                - exec.sql
```

I tried to prefix the filename with the bundle name but it unfortunately didn't work. 
Tinkered around a bit and found this to work.

The following change allows us to have the same code on JS and actually be able to access the file.

```
    const moved = await moveAssetsDatabase({
      filename: 'main.db',
      path: 'db.bundle',
    });
```

I'm not that knowledgeable with Swift/Objective-C so I am not sure if this is the optimal way to do it 