### PR TITLE
Remove runtime_error for empty encryptionKey when using SQLCipher

### DIFF
--- a/cpp/bindings.cpp
+++ b/cpp/bindings.cpp
@@ -65,13 +65,6 @@ void install(jsi::Runtime &rt, std::shared_ptr<react::CallInvoker> invoker,
           options.getProperty(rt, "encryptionKey").asString(rt).utf8(rt);
     }
 
-#ifdef OP_SQLITE_USE_SQLCIPHER
-    if (encryptionKey.empty()) {
-      throw std::runtime_error(
-          "[OP SQLite] using SQLCipher encryption key is required");
-    }
-#endif
-
     if (!location.empty()) {
       if (location == ":memory:") {
         path = ":memory:";


### PR DESCRIPTION
This is needed if you want to migrate an unencrypted database to an encrypted one

https://stackoverflow.com/a/39512020

https://github.com/sqlcipher/sqlcipher-android-tests/blob/master/app/src/main/java/net/zetetic/tests/ImportUnencryptedDatabaseTest.java