### PR TITLE
fix expo build for cr sql

### DIFF
--- a/ios/crsqlite.xcframework/Info.plist
+++ b/ios/crsqlite.xcframework/Info.plist
@@ -36,5 +36,11 @@
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>
 	<string>1.0</string>
+	<key>CFBundleVersion</key>
+  	<string>1.0.0</string>
+  	<key>CFBundleShortVersionString</key>
+  	<string>1.0.0</string>
+	<key>MinimumOSVersion</key>
+  	<string>8.0</string>
 </dict>
 </plist>

--- a/ios/crsqlite.xcframework/ios-arm64/crsqlite.framework/Info.plist
+++ b/ios/crsqlite.xcframework/ios-arm64/crsqlite.framework/Info.plist
@@ -14,5 +14,11 @@
   <string>FMWK</string>
   <key>CFBundleSignature</key>
   <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>1.0.0</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0.0</string>
+	<key>MinimumOSVersion</key>
+  <string>8.0</string>
 </dict>
 </plist>

--- a/ios/crsqlite.xcframework/ios-arm64_x86_64-simulator/crsqlite.framework/Info.plist
+++ b/ios/crsqlite.xcframework/ios-arm64_x86_64-simulator/crsqlite.framework/Info.plist
@@ -14,5 +14,11 @@
   <string>FMWK</string>
   <key>CFBundleSignature</key>
   <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>1.0.0</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0.0</string>
+	<key>MinimumOSVersion</key>
+  <string>8.0</string>
 </dict>
 </plist>


### PR DESCRIPTION
Currently there’s an issue submitting an app to the Apple App Store due to a missing version definitions in the cr-sqlite plist files.
For reference, expo-sqlite have experienced the same (see commit https://github.com/expo/expo/commit/de2a96986b29ebc8c71e291a12121e00290e9986)
This PR adds the missing version definitions and allows the app to be submitted to App Store without Apple rejecting the binary.