### PR TITLE
remove guard

### DIFF
--- a/op-sqlite.podspec
+++ b/op-sqlite.podspec
@@ -130,10 +130,6 @@ Pod::Spec.new do |s|
   end
 
   if use_libsql then
-    if use_crsqlite then
-      raise "Cannot use CRSQLite and libsql at the same time"
-    end
-
     if use_sqlcipher then
       raise "Cannot use SQLCipher and libsql at the same time"
     end


### PR DESCRIPTION
We have a use case that depends on libsql and CR-SQL 
New versions of libsql support already a extension loading 
Could we bring a CR-sql back ?