### PR TITLE
exclude libreactnative.so

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -164,7 +164,8 @@ android {
               "**/libreact_nativemodule_core.so",
               "**/libturbomodulejsijni.so",
               "**/libc++_shared.so",
-              "**/libfbjni.so"
+              "**/libfbjni.so",
+              "**/libreactnative.so",
       ]
     }
     


### PR DESCRIPTION
I was testing the newly released 9.2.5 with RN 0.76 (thanks for adding the prompt support) but ran into a build error on android:

```
Execution failed for task ':app:mergeReleaseNativeLibs'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.MergeNativeLibsTask$MergeNativeLibsTaskWorkAction
   > 2 files found with path 'lib/arm64-v8a/libreactnative.so' from inputs:
```

This submitted diff appeared to resolve the issue for me.