### PR TITLE
Add synchronous execute function

### DIFF
--- a/cpp/DBHostObject.h
+++ b/cpp/DBHostObject.h
@@ -60,6 +60,9 @@ public:
   void invalidate();
   ~DBHostObject();
 
+  // Declare the new executeSync function
+  jsi::Value executeSync(jsi::Runtime &rt, const jsi::Value *args, size_t count);
+
 private:
     std::set<std::shared_ptr<ReactiveQuery>> pending_reactive_queries;
   void auto_register_update_hook();

--- a/cpp/libsql/bridge.h
+++ b/cpp/libsql/bridge.h
@@ -59,15 +59,15 @@ BridgeResult opsqlite_libsql_execute(
     std::string const &name, std::string const &query,
     const std::vector<JSVariant> *params);
 
-    BridgeResult opsqlite_libsql_execute_with_host_objects(
-            std::string const &name, std::string const &query,
-            const std::vector<JSVariant> *params, std::vector<DumbHostObject> *results,
+BridgeResult opsqlite_libsql_execute_with_host_objects(
+    std::string const &name, std::string const &query,
+    const std::vector<JSVariant> *params, std::vector<DumbHostObject> *results,
             const std::shared_ptr<std::vector<SmartHostObject>>& metadatas);
 
 BridgeResult
 opsqlite_libsql_execute_raw(std::string const &dbName, std::string const &query,
-                            const std::vector<JSVariant> *params,
-                            std::vector<std::vector<JSVariant>> *results);
+    const std::vector<JSVariant> *params,
+    std::vector<std::vector<JSVariant>> *results);
 
 BatchResult
 opsqlite_libsql_execute_batch(std::string const &name,
@@ -84,6 +84,10 @@ void opsqlite_libsql_bind_statement(libsql_stmt_t stmt,
 BridgeResult opsqlite_libsql_execute_prepared_statement(
     std::string const &name, libsql_stmt_t stmt,
     std::vector<DumbHostObject> *results,
-    const std::shared_ptr<std::vector<SmartHostObject>>& metadatas);
+    const std::shared_ptr<std::vector<SmartHostObject>> &metadatas);
+
+BridgeResult opsqlite_libsql_execute_sync(
+    std::string const &name, std::string const &query,
+    const std::vector<JSVariant> *params);
 
 } // namespace opsqlite

--- a/example/src/tests/queries.spec.ts
+++ b/example/src/tests/queries.spec.ts
@@ -652,5 +652,27 @@ export function queriesTests() {
       await db.execute('SELECT 1; ', []);
       await db.execute('SELECT ?; ', [1]);
     });
+
+    it('Synchronous execute', () => {
+      const id = chance.integer();
+      const name = chance.name();
+      const age = chance.integer();
+      const networth = chance.floating();
+      db.executeSync(
+        'INSERT INTO User (id, name, age, networth) VALUES(?, ?, ?, ?)',
+        [id, name, age, networth],
+      );
+
+      const res = db.executeSync('SELECT * FROM User');
+      expect(res.rows).to.eql([
+        {
+          id,
+          name,
+          age,
+          networth,
+          nickname: null,
+        },
+      ]);
+    });
   });
 }


### PR DESCRIPTION
Fixes #173

Add synchronous execute API to the project.

* **cpp/DBHostObject.cpp**
  - Add a new `executeSync` function for synchronous execution.
  - Directly call `opsqlite_execute` without using `invokeAsync`.
  - Register the new `executeSync` function in the function map.
* **cpp/libsql/bridge.cpp**
  - Add a new `executeSync` function for synchronous execution.
  - Directly call `libsql_query_stmt` without using `libsql_prepare`.
* **cpp/DBHostObject.h**
  - Declare the new `executeSync` function.
* **cpp/libsql/bridge.h**
  - Declare the new `executeSync` function.
* **example/src/tests/queries.spec.ts**
  - Add test cases for the new `executeSync` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/OP-Engineering/op-sqlite/pull/186?shareId=ce2ef2ac-d167-4b9e-8287-fcaccd1574db).