### PR TITLE
Add getDylibPath for loading runtime extensions on iOS

### DIFF
--- a/android/src/main/java/com/op/sqlite/OPSQLiteModule.kt
+++ b/android/src/main/java/com/op/sqlite/OPSQLiteModule.kt
@@ -50,6 +50,11 @@ internal class OPSQLiteModule(context: ReactApplicationContext?) : ReactContextB
         }
     }
 
+    @ReactMethod(isBlockingSynchronousMethod = true)
+    fun getDylibPath(bundleId: String, name: String) {
+        throw Exception("Do not call getDylibPath on Android")
+    }
+
     @ReactMethod
     fun moveAssetsDatabase(args: ReadableMap, promise: Promise) {
         val filename = args.getString("filename")!!

--- a/cpp/bridge.cpp
+++ b/cpp/bridge.cpp
@@ -988,28 +988,30 @@ BridgeResult opsqlite_load_extension(std::string const &db_name,
                                      std::string &entry_point) {
 #ifdef OP_SQLITE_USE_PHONE_VERSION
   throw std::runtime_error(
-      "Embedded version of SQLite does not support loading extensions");
+      "[op-sqlite] Embedded version of SQLite does not support loading extensions");
 #else
   check_db_open(db_name);
 
   sqlite3 *db = dbMap[db_name];
-  int loading_extensions_enabled = sqlite3_enable_load_extension(db, 1);
-  if (loading_extensions_enabled != SQLITE_OK) {
+  int status = 0;
+  status = sqlite3_enable_load_extension(db, 1);
+  if (status != SQLITE_OK) {
     return {SQLiteError, "[op-sqlite] could not enable extension loading"};
   }
-  const char *path_cstr = path.c_str();
-  const char *entry_point_cstr;
+
+  const char *entry_point_cstr = nullptr;
   if (!entry_point.empty()) {
     entry_point_cstr = entry_point.c_str();
   }
 
   char *error_message;
 
-  int extension_loaded =
-      sqlite3_load_extension(db, path_cstr, entry_point_cstr, &error_message);
-  if (extension_loaded != SQLITE_OK) {
+  status = sqlite3_load_extension(db, path.c_str(), entry_point_cstr,
+                                  &error_message);
+  if (status != SQLITE_OK) {
     return {SQLiteError, std::string(error_message)};
   }
+    
   return {SQLiteOk};
 #endif
 }

--- a/example/ios/OPSQLiteExample.xcodeproj/project.pbxproj
+++ b/example/ios/OPSQLiteExample.xcodeproj/project.pbxproj
@@ -11,7 +11,6 @@
 		13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.mm */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
-		3B5A9E3FD2C56B364AF5A4F3 /* libPods-OPSQLiteExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6EE3066EB7AAB7E17B1CAB50 /* libPods-OPSQLiteExample.a */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 		92B54B8E74B0B43081C567EF /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 2C08DBE2BF8FD676ED5D600B /* PrivacyInfo.xcprivacy */; };
 		AC1DF06E9759460CAA51B7B1 /* sample2.sqlite in Resources */ = {isa = PBXBuildFile; fileRef = 9218E48CFB1F478CAC374D68 /* sample2.sqlite */; };
@@ -24,11 +23,9 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = OPSQLiteExample/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = OPSQLiteExample/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = OPSQLiteExample/main.m; sourceTree = "<group>"; };
-		19F6CBCC0A4E27FBF8BF4A61 /* libPods-OPSQLiteExample-OPSQLiteExampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-OPSQLiteExample-OPSQLiteExampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		2C08DBE2BF8FD676ED5D600B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = OPSQLiteExample/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		2C08DBE2BF8FD676ED5D600B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = OPSQLiteExample/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		3B4392A12AC88292D35C810B /* Pods-OPSQLiteExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OPSQLiteExample.debug.xcconfig"; path = "Target Support Files/Pods-OPSQLiteExample/Pods-OPSQLiteExample.debug.xcconfig"; sourceTree = "<group>"; };
 		5709B34CF0A7D63546082F79 /* Pods-OPSQLiteExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OPSQLiteExample.release.xcconfig"; path = "Target Support Files/Pods-OPSQLiteExample/Pods-OPSQLiteExample.release.xcconfig"; sourceTree = "<group>"; };
-		6EE3066EB7AAB7E17B1CAB50 /* libPods-OPSQLiteExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-OPSQLiteExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = OPSQLiteExample/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		9218E48CFB1F478CAC374D68 /* sample2.sqlite */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = sample2.sqlite; path = ../assets/sqlite/sample2.sqlite; sourceTree = "<group>"; };
 		96FD9FD0FC4F4540AC7A9CE6 /* sample.sqlite */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = sample.sqlite; path = ../assets/sample.sqlite; sourceTree = "<group>"; };
@@ -40,7 +37,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3B5A9E3FD2C56B364AF5A4F3 /* libPods-OPSQLiteExample.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -65,8 +61,6 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				19F6CBCC0A4E27FBF8BF4A61 /* libPods-OPSQLiteExample-OPSQLiteExampleTests.a */,
-				6EE3066EB7AAB7E17B1CAB50 /* libPods-OPSQLiteExample.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -438,10 +432,7 @@
 				);
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_CFLAGS = "$(inherited)  ";
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
 					"-DFOLLY_NO_CONFIG",
@@ -528,10 +519,7 @@
 					"\"$(inherited)\"",
 				);
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_CFLAGS = "$(inherited)  ";
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
 					"-DFOLLY_NO_CONFIG",

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,9 +1,10 @@
-import {open} from '@op-engineering/op-sqlite';
+import {getDylibPath, open} from '@op-engineering/op-sqlite';
 import clsx from 'clsx';
 import {useEffect, useState} from 'react';
 import {
   Button,
   Clipboard,
+  Platform,
   SafeAreaView,
   ScrollView,
   Text,
@@ -131,10 +132,27 @@ export default function App() {
     }, 200);
   };
 
+  const loadExtention = async () => {
+    try {
+      let db = open({name: 'extension.sqlite'});
+      let path = 'libcrsqlite';
+      if (Platform.OS === 'ios') {
+        console.log('Getting new path');
+        path = getDylibPath('io.vlcn.crsqlite', 'crsqlite');
+      }
+      console.log(`final path ${path}`);
+      db.loadExtension(path);
+      console.log('Loaded extension!');
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
   return (
     <SafeAreaView className="flex-1 bg-neutral-900">
       <ScrollView>
         <Button title="Reload app middle of query" onPress={queryAndReload} />
+        <Button title="Load extension" onPress={loadExtention} />
         <Button title="Share DB" onPress={shareDb} />
         <Button title="Copy DB Path" onPress={copyDbPathToClipboad} />
         <Button title="Create 300k Record DB" onPress={createLargeDb} />

--- a/ios/OPSQLite.mm
+++ b/ios/OPSQLite.mm
@@ -93,6 +93,13 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install) {
   return @true;
 }
 
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getDylibPath : (
+    NSString *)bundleId andResource : (NSString *)resourceName) {
+  NSBundle *bundle = [NSBundle bundleWithIdentifier:bundleId];
+  NSString *path = [bundle pathForResource:resourceName ofType:@""];
+  return path;
+}
+
 RCT_EXPORT_METHOD(moveAssetsDatabase : (NSDictionary *)args resolve : (
     RCTPromiseResolveBlock)resolve reject : (RCTPromiseRejectBlock)reject) {
   NSString *documentPath = [NSSearchPathForDirectoriesInDomains(

--- a/src/index.ts
+++ b/src/index.ts
@@ -465,6 +465,10 @@ export const moveAssetsDatabase = async (args: {
   return NativeModules.OPSQLite.moveAssetsDatabase(args);
 };
 
+export const getDylibPath = (bundle: string, name: string): string => {
+  return NativeModules.OPSQLite.getDylibPath(bundle, name);
+};
+
 export const isSQLCipher = (): boolean => {
   return OPSQLite.isSQLCipher();
 };


### PR DESCRIPTION
It's now possible to load dylibs on iOS to call the sqlite method to load an extension. This was always possible on Android but on iOS dylibs are heavily restricted and packaged into frameworks, this requires to get the runtime path of the packaged binary from iOS APIs. There is now a method one can use to get the binary path on iOS and pass the full path to the loadExtension call to sqlite.

Docs are updated, scroll down to loading extensions:

https://ospfranco.notion.site/API-1a39b6bb3eb74eb893d640c8c3459362