### PR TITLE
Fix MinimumOSVersion in sqlitevec.xcframework

### DIFF
--- a/ios/sqlitevec.xcframework/ios-arm64/sqlitevec.framework/Info.plist
+++ b/ios/sqlitevec.xcframework/ios-arm64/sqlitevec.framework/Info.plist
@@ -18,7 +18,7 @@
   <string>1.0.0</string>
   <key>CFBundleShortVersionString</key>
   <string>1.0.0</string>
-	<key>MinimumOSVersion</key>
-  <string>8.0</string>
+  <key>MinimumOSVersion</key>
+  <string>13.0</string>
 </dict>
 </plist>

--- a/ios/sqlitevec.xcframework/ios-arm64_x86_64-simulator/sqlitevec.framework/Info.plist
+++ b/ios/sqlitevec.xcframework/ios-arm64_x86_64-simulator/sqlitevec.framework/Info.plist
@@ -18,7 +18,7 @@
   <string>1.0.0</string>
   <key>CFBundleShortVersionString</key>
   <string>1.0.0</string>
-	<key>MinimumOSVersion</key>
-  <string>8.0</string>
+  <key>MinimumOSVersion</key>
+  <string>13.0</string>
 </dict>
 </plist>


### PR DESCRIPTION
It was missed in #216.

I got the version mismatched error on upload app to TestFlight, and confirmed it can be fixed by this PR.