### PR TITLE
fix: open function is undefined

### DIFF
--- a/src/Storage.ts
+++ b/src/Storage.ts
@@ -1,4 +1,4 @@
-import { open, type DB } from '.';
+import { open, type DB } from './index';
 
 type StorageOptions = {
   location?: string;


### PR DESCRIPTION
I've tried to use the KV Storage class from op-sqlite but got the error `[TypeError: 0, _.open is not a function (it is undefined)]` on android (weirdly enough it works on ios).
I've fixed the error by changing the import in Storage.ts from:
```ts
import { open, type DB } from '.';
```

to
```ts
import { open, type DB } from './index';
```
