### PR TITLE
fix podspec file to resolve symlinks to find package.json

### DIFF
--- a/op-sqlite.podspec
+++ b/op-sqlite.podspec
@@ -14,7 +14,7 @@ parent_folder_name = File.basename(__dir__)
 app_package = nil
 # When installed on user node_modules lives inside node_modules/@op-engineering/op-sqlite
 if is_user_app
-  app_package = JSON.parse(File.read(File.join(__dir__, "..", "..", "..", "package.json")))
+  app_package = JSON.parse(File.read(File.expand_path("../../../../../package.json", __dir__)))
 # When running on the example app
 else
   app_package = JSON.parse(File.read(File.join(__dir__, "example", "package.json")))


### PR DESCRIPTION
`File.expand_path` properly resolves symlinks, so this should fix #172 
I tested this in both a monorepo project with symlinked node_modules, and also a non-monorepo project.
Let me know if you have any concerns.