### PR TITLE
find package.json in parent directories in podspec file

### DIFF
--- a/op-sqlite.podspec
+++ b/op-sqlite.podspec
@@ -14,7 +14,25 @@ parent_folder_name = File.basename(__dir__)
 app_package = nil
 # When installed on user node_modules lives inside node_modules/@op-engineering/op-sqlite
 if is_user_app
-  app_package = JSON.parse(File.read(File.join(__dir__, "..", "..", "..", "package.json")))
+  current_dir = File.expand_path(__dir__)
+  package_json_path = nil
+  
+  # Find the package.json by searching up through parent directories
+  loop do
+    package_path = File.join(current_dir, "package.json")
+    if File.exist?(package_path)
+      package_json_path = package_path
+      break
+    end
+
+    parent_dir = File.dirname(current_dir)
+    break if parent_dir == current_dir  # reached filesystem root
+    current_dir = parent_dir
+  end
+  
+  raise "package.json not found" if package_json_path.nil?
+  
+  app_package = JSON.parse(File.read(package_json_path))
 # When running on the example app
 else
   app_package = JSON.parse(File.read(File.join(__dir__, "example", "package.json")))


### PR DESCRIPTION
Sorry about the last one, this time this should properly fix #172

I created 2 repositories that include patches with this change to test this.
A non-monorepo project:
```
git clone https://github.com/bviebahn/op-sqlite-expo.git
cd op-sqlite-expo
npm i
npm run prebuild
```

And a monorepo project:
```
git clone https://github.com/bviebahn/op-sqlite-monorepo.git
cd op-sqlite-monorepo
pnpm i
cd apps/mobile
pnpm prebuild
```

prebuild will run `pod install`, you should see `✔ Installed CocoaPods` at the end.
In the monorepo project, you can also remove the patch from the root package.json, to verify that installing pods fails without the patch.

Let me know if I missed something @ospfranco 