### PR TITLE
monorepo warning

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -24,6 +24,12 @@ This package only runs on `iOS`, `Android` and `macOS`, same as `expo-sqlite`, t
 
 SQLite is very customizable on compilation level. op-sqlite also allows you add extensions or even change the base implementation. You can do this by adding the following to your `package.json`:
 
+> [!IMPORTANT]
+> When using a monorepo, be sure to add the "op-sqlite" config to the monorepo root `package.json` file.
+> This is necessary because the `node_modules/@op-engineering/op-sqlite/op-sqlite.podspec` will search for first the `package.json` file in a parent directory.
+> Alternative, you may be able to solve this by blocking this package from being hoisted to the root `node_modules`.
+> Check your ios/Podfile.lock to see where it's being installed.
+
 ```json
 {
   // ... the rest of your package.json


### PR DESCRIPTION
This pull request updates the installation documentation for the `op-sqlite` package to include important guidance for users working in monorepo environments.

Documentation improvements:

* [`docs/docs/installation.md`](diffhunk://#diff-19fd876fb56da88a1becb80817b52db1a40e8491641d547913b93bb7ecda3d22R27-R32): Added a note explaining that when using a monorepo, the "op-sqlite" configuration must be added to the root `package.json` file. The note also provides an alternative solution to prevent the package from being hoisted to the root `node_modules` and suggests checking the `ios/Podfile.lock` file for installation details.