### PR TITLE
Expose offline flag for libsql

### DIFF
--- a/cpp/DBHostObject.cpp
+++ b/cpp/DBHostObject.cpp
@@ -154,11 +154,11 @@ DBHostObject::DBHostObject(jsi::Runtime &rt,
                            std::shared_ptr<react::CallInvoker> invoker,
                            std::string &db_name, std::string &path,
                            std::string &url, std::string &auth_token,
-                           int sync_interval)
+                           int sync_interval, bool offline)
     : db_name(db_name), invoker(std::move(invoker)), rt(rt) {
     _thread_pool = std::make_shared<ThreadPool>();
     db = opsqlite_libsql_open_sync(db_name, path, url, auth_token,
-                                   sync_interval);
+                                   sync_interval, offline);
 
     create_jsi_functions();
 }

--- a/cpp/DBHostObject.h
+++ b/cpp/DBHostObject.h
@@ -54,7 +54,7 @@ class JSI_EXPORT DBHostObject : public jsi::HostObject {
     // Constructor for a local database with remote sync
     DBHostObject(jsi::Runtime &rt, std::shared_ptr<react::CallInvoker> invoker,
                  std::string &db_name, std::string &path, std::string &url,
-                 std::string &auth_token, int sync_interval);
+                 std::string &auth_token, int sync_interval, bool offline);
 #endif
 
     std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &rt) override;

--- a/cpp/bindings.cpp
+++ b/cpp/bindings.cpp
@@ -129,18 +129,23 @@ void install(jsi::Runtime &rt,
         std::string url = options.getProperty(rt, "url").asString(rt).utf8(rt);
         std::string auth_token =
             options.getProperty(rt, "authToken").asString(rt).utf8(rt);
+
         int sync_interval = 0;
-        if (options.hasProperty(rt, "syncInterval")) {
+        if (options.hasProperty(rt, "libsqlSyncInterval")) {
             sync_interval = static_cast<int>(
                 options.getProperty(rt, "syncInterval").asNumber());
         }
-        std::string location;
 
+        bool offline = false;
+        if (options.hasProperty(rt, "libsqlOffline")) {
+            offline = options.getProperty(rt, "libsqlOffline").asBool();
+        }
+
+        std::string location;
         if (options.hasProperty(rt, "location")) {
             location =
                 options.getProperty(rt, "location").asString(rt).utf8(rt);
         }
-
         if (!location.empty()) {
             if (location == ":memory:") {
                 path = ":memory:";
@@ -152,7 +157,7 @@ void install(jsi::Runtime &rt,
         }
 
         std::shared_ptr<DBHostObject> db = std::make_shared<DBHostObject>(
-            rt, invoker, name, path, url, auth_token, sync_interval);
+            rt, invoker, name, path, url, auth_token, sync_interval, offline);
         return jsi::Object::createFromHostObject(rt, db);
     });
 #endif

--- a/cpp/libsql/bridge.cpp
+++ b/cpp/libsql/bridge.cpp
@@ -39,7 +39,8 @@ std::string opsqlite_get_db_path(std::string const &db_name,
 DB opsqlite_libsql_open_sync(std::string const &name,
                              std::string const &base_path,
                              std::string const &url,
-                             std::string const &auth_token, int sync_interval) {
+                             std::string const &auth_token, int sync_interval,
+                             bool offline) {
     std::string path = opsqlite_get_db_path(name, base_path);
 
     int status;
@@ -53,7 +54,9 @@ DB opsqlite_libsql_open_sync(std::string const &name,
                             .read_your_writes = '1',
                             .encryption_key = nullptr,
                             .sync_interval = sync_interval,
-                            .with_webpki = '1'};
+                            .with_webpki = '1',
+                            .offline = offline};
+
     status = libsql_open_sync_with_config(config, &db, &err);
     if (status != 0) {
         throw std::runtime_error(err);

--- a/cpp/libsql/bridge.h
+++ b/cpp/libsql/bridge.h
@@ -40,7 +40,8 @@ DB opsqlite_libsql_open_remote(std::string const &url,
 
 DB opsqlite_libsql_open_sync(std::string const &name, std::string const &path,
                              std::string const &url,
-                             std::string const &auth_token, int sync_interval);
+                             std::string const &auth_token, int sync_interval,
+                             bool offline);
 
 void opsqlite_libsql_close(DB &db);
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -14,7 +14,6 @@ PODS:
     - DoubleConversion
     - glog
     - hermes-engine
-    - OpenSSL-Universal
     - RCT-Folly (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
@@ -34,7 +33,6 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - OpenSSL-Universal (3.3.3001)
   - RCT-Folly (2024.01.01.00):
     - boost
     - DoubleConversion
@@ -1640,7 +1638,6 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - GCDWebServer
-    - OpenSSL-Universal
     - SocketRocket
 
 EXTERNAL SOURCES:
@@ -1788,8 +1785,7 @@ SPEC CHECKSUMS:
   GCDWebServer: 2c156a56c8226e2d5c0c3f208a3621ccffbe3ce4
   glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
   hermes-engine: 06a9c6900587420b90accc394199527c64259db4
-  op-sqlite: f41ba334d2e4bb6126c22751e6aa5645c4b5cf46
-  OpenSSL-Universal: 6082b0bf950e5636fe0d78def171184e2b3899c2
+  op-sqlite: 94ed545f045bdcc18e9daeda43467fe30a5835fe
   RCT-Folly: bf5c0376ffe4dd2cf438dcf86db385df9fdce648
   RCTDeprecation: fb7d408617e25d7f537940000d766d60149c5fea
   RCTRequired: 9aaf0ffcc1f41f0c671af863970ef25c422a9920

--- a/example/package.json
+++ b/example/package.json
@@ -66,8 +66,8 @@
     "node": ">=18"
   },
   "op-sqlite": {
-    "libsql": false,
-    "sqlcipher": true,
+    "libsql": true,
+    "sqlcipher": false,
     "iosSqlite": false,
     "fts5": true,
     "rtree": true,

--- a/example/src/tests/storage.spec.ts
+++ b/example/src/tests/storage.spec.ts
@@ -1,6 +1,6 @@
 import {Storage} from '@op-engineering/op-sqlite';
 import chai from 'chai';
-import {afterEach, beforeEach, describe, it} from './MochaRNAdapter';
+import {beforeEach, describe, it} from './MochaRNAdapter';
 
 const expect = chai.expect;
 
@@ -11,8 +11,6 @@ export function storageTests() {
     beforeEach(async () => {
       storage = new Storage({encryptionKey: 'test'});
     });
-
-    afterEach(() => {});
 
     it('Can set and get sync', async () => {
       storage.setItemSync('foo', 'bar');

--- a/src/index.ts
+++ b/src/index.ts
@@ -629,7 +629,8 @@ export const openSync = (params: {
   authToken: string;
   name: string;
   location?: string;
-  syncInterval?: number;
+  libsqlSyncInterval?: number;
+  libsqlOffline?: boolean;
 }): DB => {
   if (!isLibsql()) {
     throw new Error('This function is only available for libsql');


### PR DESCRIPTION
renamed the `syncInterval` param to `libsqlSyncInterval` and add a new `libsqlOffline` param to the `openSync` call