### PR TITLE
Fix libsqlSyncInterval parameter handling in openSync function

### DIFF
--- a/cpp/bindings.cpp
+++ b/cpp/bindings.cpp
@@ -133,7 +133,7 @@ void install(jsi::Runtime &rt,
         int sync_interval = 0;
         if (options.hasProperty(rt, "libsqlSyncInterval")) {
             sync_interval = static_cast<int>(
-                options.getProperty(rt, "syncInterval").asNumber());
+                options.getProperty(rt, "libsqlSyncInterval").asNumber());
         }
 
         bool offline = false;


### PR DESCRIPTION
Fixed a bug in cpp/bindings.cpp where the code was checking for the property "libsqlSyncInterval" but then trying to read "syncInterval" instead. This mismatch caused the native code to attempt to read an undefined property, resulting in the JSI error.

This bug was likely introduced during the rename from syncInterval to libsqlSyncInterval in PR #272, where this specific line wasn't updated correctly. The fix ensures that the libsqlSyncInterval parameter is properly passed through to the native libsql configuration.

