### PR TITLE
Add new param to libsql openSync, encryptionKey, which enables encryption

### DIFF
--- a/cpp/DBHostObject.cpp
+++ b/cpp/DBHostObject.cpp
@@ -140,6 +140,7 @@ void DBHostObject::auto_register_update_hook() {
 //  | |___| (_) | | | \__ \ |_| |  | |_| | (__| || (_) | |
 //   \_____\___/|_| |_|___/\__|_|   \__,_|\___|\__\___/|_|
 #ifdef OP_SQLITE_USE_LIBSQL
+// Remote connection constructor
 DBHostObject::DBHostObject(jsi::Runtime &rt, std::string &url,
                            std::string &auth_token,
                            std::shared_ptr<react::CallInvoker> invoker)
@@ -150,15 +151,19 @@ DBHostObject::DBHostObject(jsi::Runtime &rt, std::string &url,
     create_jsi_functions();
 }
 
+// Sync connection constructor
 DBHostObject::DBHostObject(jsi::Runtime &rt,
                            std::shared_ptr<react::CallInvoker> invoker,
                            std::string &db_name, std::string &path,
                            std::string &url, std::string &auth_token,
-                           int sync_interval, bool offline)
+                           int sync_interval, bool offline,
+                           std::string &encryption_key)
     : db_name(db_name), invoker(std::move(invoker)), rt(rt) {
+
     _thread_pool = std::make_shared<ThreadPool>();
+
     db = opsqlite_libsql_open_sync(db_name, path, url, auth_token,
-                                   sync_interval, offline);
+                                   sync_interval, offline, encryption_key);
 
     create_jsi_functions();
 }

--- a/cpp/DBHostObject.h
+++ b/cpp/DBHostObject.h
@@ -54,7 +54,8 @@ class JSI_EXPORT DBHostObject : public jsi::HostObject {
     // Constructor for a local database with remote sync
     DBHostObject(jsi::Runtime &rt, std::shared_ptr<react::CallInvoker> invoker,
                  std::string &db_name, std::string &path, std::string &url,
-                 std::string &auth_token, int sync_interval, bool offline);
+                 std::string &auth_token, int sync_interval, bool offline,
+                 std::string &encryption_key);
 #endif
 
     std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &rt) override;

--- a/cpp/bindings.cpp
+++ b/cpp/bindings.cpp
@@ -112,12 +112,15 @@ void install(jsi::Runtime &rt,
 #ifdef OP_SQLITE_USE_LIBSQL
     auto open_remote = HOST_STATIC_FN("openRemote") {
         jsi::Object options = args[0].asObject(rt);
+      
         std::string url = options.getProperty(rt, "url").asString(rt).utf8(rt);
+      
         std::string auth_token =
             options.getProperty(rt, "authToken").asString(rt).utf8(rt);
-
-        std::shared_ptr<DBHostObject> db =
-            std::make_shared<DBHostObject>(rt, url, auth_token, invoker);
+      
+        std::shared_ptr<DBHostObject> db = std::make_shared<DBHostObject>(
+            rt, url, auth_token, invoker);
+      
         return jsi::Object::createFromHostObject(rt, db);
     });
 
@@ -141,6 +144,12 @@ void install(jsi::Runtime &rt,
             offline = options.getProperty(rt, "libsqlOffline").asBool();
         }
 
+        std::string encryption_key;
+        if (options.hasProperty(rt, "encryptionKey")) {
+            encryption_key =
+                options.getProperty(rt, "encryptionKey").asString(rt).utf8(rt);
+        }
+
         std::string location;
         if (options.hasProperty(rt, "location")) {
             location =
@@ -157,7 +166,7 @@ void install(jsi::Runtime &rt,
         }
 
         std::shared_ptr<DBHostObject> db = std::make_shared<DBHostObject>(
-            rt, invoker, name, path, url, auth_token, sync_interval, offline);
+            rt, invoker, name, path, url, auth_token, sync_interval, offline, encryption_key);
         return jsi::Object::createFromHostObject(rt, db);
     });
 #endif

--- a/cpp/libsql/bridge.cpp
+++ b/cpp/libsql/bridge.cpp
@@ -40,7 +40,7 @@ DB opsqlite_libsql_open_sync(std::string const &name,
                              std::string const &base_path,
                              std::string const &url,
                              std::string const &auth_token, int sync_interval,
-                             bool offline) {
+                             bool offline, std::string const &encryption_key) {
     std::string path = opsqlite_get_db_path(name, base_path);
 
     int status;
@@ -52,7 +52,7 @@ DB opsqlite_libsql_open_sync(std::string const &name,
                             .primary_url = url.c_str(),
                             .auth_token = auth_token.c_str(),
                             .read_your_writes = '1',
-                            .encryption_key = nullptr,
+                            .encryption_key = encryption_key.c_str(),
                             .sync_interval = sync_interval,
                             .with_webpki = '1',
                             .offline = offline};

--- a/cpp/libsql/bridge.h
+++ b/cpp/libsql/bridge.h
@@ -41,7 +41,7 @@ DB opsqlite_libsql_open_remote(std::string const &url,
 DB opsqlite_libsql_open_sync(std::string const &name, std::string const &path,
                              std::string const &url,
                              std::string const &auth_token, int sync_interval,
-                             bool offline);
+                             bool offline, std::string const &encryption_key);
 
 void opsqlite_libsql_close(DB &db);
 

--- a/docs/docs/Libsql/start.md
+++ b/docs/docs/Libsql/start.md
@@ -39,8 +39,11 @@ const remoteDb = openSync({
   url: 'url',
   authToken: 'token',
   syncInterval: 1, // Optional, in seconds
+  encryptionKey: 'my encryption key', // Optional, will encrypt the database on device. Will add overhead to your queries
 });
 ```
+
+Be careful when setting an encryption key as you need to keep your key secure. [Read more about React Native security](https://ospfranco.com/react-native-security-guide/).
 
 ## Sync Database
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1958,75 +1958,75 @@ SPEC CHECKSUMS:
   GCDWebServer: 2c156a56c8226e2d5c0c3f208a3621ccffbe3ce4
   glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
   hermes-engine: 314be5250afa5692b57b4dd1705959e1973a8ebe
-  op-sqlite: 3542bd9b1f45190426e95ee3873b09349be96335
+  op-sqlite: d58de9322037133d8da81961b1cb49fc799e2e46
   RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: 83ffb90c23ee5cea353bd32008a7bca100908f8c
   RCTRequired: eb7c0aba998009f47a540bec9e9d69a54f68136e
   RCTTypeSafety: 659ae318c09de0477fd27bbc9e140071c7ea5c93
   React: c2d3aa44c49bb34e4dfd49d3ee92da5ebacc1c1c
   React-callinvoker: 1bdfb7549b5af266d85757193b5069f60659ef9d
-  React-Core: 10597593fdbae06f0089881e025a172e51d4a769
-  React-CoreModules: 6907b255529dd46895cf687daa67b24484a612c2
-  React-cxxreact: a9f5b8180d6955bc3f6a3fcd657c4d9b4d95c1f6
+  React-Core: 7150cf9b6a5af063b37003062689f1691e79c020
+  React-CoreModules: 15a85e6665d61678942da6ae485b351f4c699049
+  React-cxxreact: 74f9de59259ac951923f5726aa14f0398f167af9
   React-debug: e74e76912b91e08d580c481c34881899ccf63da9
-  React-defaultsnativemodule: 11f6ee2cf69bf3af9d0f28a6253def33d21b5266
-  React-domnativemodule: f940bbc4fa9e134190acbf3a4a9f95621b5a8f51
-  React-Fabric: 6f5c357bf3a42ff11f8844ad3fc7a1eb04f4b9de
-  React-FabricComponents: 10e0c0209822ac9e69412913a8af1ca33573379b
-  React-FabricImage: f582e764072dfa4715ae8c42979a5bace9cbcc12
+  React-defaultsnativemodule: 628285212bbd65417d40ad6a9f8781830fda6c98
+  React-domnativemodule: 185d9808198405c176784aaf33403d713bd24fb7
+  React-Fabric: c814804affbe1952e16149ddd20256e1bccae67e
+  React-FabricComponents: 81ef47d596966121784afec9924f9562a29b1691
+  React-FabricImage: f14f371d678aa557101def954ac3ba27e48948ff
   React-featureflags: d5facceff8f8f6de430e0acecf4979a9a0839ba9
-  React-featureflagsnativemodule: a7dd141f1ef4b7c1331af0035689fbc742a49ff4
-  React-graphics: 36ae3407172c1c77cea29265d2b12b90aaef6aa0
-  React-hermes: 9116d4e6d07abeb519a2852672de087f44da8f12
-  React-idlecallbacksnativemodule: ae7f5ffc6cf2d2058b007b78248e5b08172ad5c3
-  React-ImageManager: 9daee0dc99ad6a001d4b9e691fbf37107e2b7b54
-  React-jserrorhandler: 1e6211581071edaf4ecd5303147328120c73f4dc
-  React-jsi: 753ba30c902f3a41fa7f956aca8eea3317a44ee6
-  React-jsiexecutor: 47520714aa7d9589c51c0f3713dfbfca4895d4f9
-  React-jsinspector: cfd27107f6d6f1076a57d88c932401251560fe5f
-  React-jsinspectortracing: 76a7d791f3c0c09a0d2bf6f46dfb0e79a4fcc0ac
-  React-jsitooling: 995e826570dd58f802251490486ebd3244a037ab
-  React-jsitracing: 094ae3d8c123cea67b50211c945b7c0443d3e97b
-  React-logger: 8edfcedc100544791cd82692ca5a574240a16219
-  React-Mapbuffer: c3f4b608e4a59dd2f6a416ef4d47a14400194468
-  React-microtasksnativemodule: 054f34e9b82f02bd40f09cebd4083828b5b2beb6
-  react-native-http-bridge-refurbished: 1bd13b32a8e62abe61bab809c26e2dcf21256ed7
-  react-native-restart: 0bc732f4461709022a742bb29bcccf6bbc5b4863
-  React-NativeModulesApple: 2c4377e139522c3d73f5df582e4f051a838ff25e
+  React-featureflagsnativemodule: 96f0ab285382d95c90f663e02526a5ceefa95a11
+  React-graphics: 1a66ee0a3f093b125b853f6370296fadcaf6f233
+  React-hermes: 8b86e5f54a65ecb69cdf22b3a00a11562eda82d2
+  React-idlecallbacksnativemodule: 5c25ab145c602264d00cb26a397ab52e0efa031c
+  React-ImageManager: 15e34bd5ef1ac4a18e96660817ef70a7f99ee8c2
+  React-jserrorhandler: 02cdf2cd45350108be1ffd2b164578936dbbdff7
+  React-jsi: 6af1987cfbb1b6621664fdbf6c7b62bd4d38c923
+  React-jsiexecutor: 51f372998e0303585cb0317232b938d694663cbd
+  React-jsinspector: 3539ad976d073bfaa8a7d2fa9bef35e70e55033e
+  React-jsinspectortracing: e8dbacaf67c201f23052ca1c2bae2f7b84dec443
+  React-jsitooling: 95a34f41e3c249d42181de13b4f8d854f178ca9f
+  React-jsitracing: 25b029cf5cad488252d46da19dd8c4c134fd5fe4
+  React-logger: 368570a253f00879a1e4fea24ed4047e72e7bbf3
+  React-Mapbuffer: c04fcda1c6281fc0a6824c7dcc1633dd217ac1ec
+  React-microtasksnativemodule: ca2804a25fdcefffa0aa942aa23ab53b99614a34
+  react-native-http-bridge-refurbished: e2e45508ec1573999ace69a0b880eee8f0e5bab2
+  react-native-restart: 7595693413fe3ca15893702f2c8306c62a708162
+  React-NativeModulesApple: 452b86b29fae99ed0a4015dca3ad9cd222f88abf
   React-oscompat: ef5df1c734f19b8003e149317d041b8ce1f7d29c
-  React-perflogger: 9a151e0b4c933c9205fd648c246506a83f31395d
-  React-performancetimeline: 5b0dfc0acba29ea0269ddb34cd6dd59d3b8a1c66
+  React-perflogger: 6fd2f6811533e9c19a61e855c3033eecbf4ad2a0
+  React-performancetimeline: abf31259d794c9274b3ea19c5016186925eec6c4
   React-RCTActionSheet: a499b0d6d9793886b67ba3e16046a3fef2cdbbc3
-  React-RCTAnimation: cc64adc259aabc3354b73065e2231d796dfce576
-  React-RCTAppDelegate: 9d523da768f1c9e84c5f3b7e3624d097dfb0e16b
-  React-RCTBlob: e727f53eeefded7e6432eb76bd22b57bc880e5d1
-  React-RCTFabric: 58590aa4fdb4ad546c06a7449b486cf6844e991f
-  React-RCTFBReactNativeSpec: 9064c63d99e467a3893e328ba3612745c3c3a338
-  React-RCTImage: 7159cbdbb18a09d97ba1a611416eced75b3ccb29
-  React-RCTLinking: 46293afdb859bccc63e1d3dedc6901a3c04ef360
-  React-RCTNetwork: 4a6cd18f5bcd0363657789c64043123a896b1170
-  React-RCTRuntime: 5ab904fd749aa52f267ef771d265612582a17880
-  React-RCTSettings: 61e361dc85136d1cb0e148b7541993d2ee950ea7
-  React-RCTText: abd1e196c3167175e6baef18199c6d9d8ac54b4e
-  React-RCTVibration: 490e0dcb01a3fe4a0dfb7bc51ad5856d8b84f343
+  React-RCTAnimation: 2595dcb10a82216a511b54742f8c28d793852ac6
+  React-RCTAppDelegate: f03604b70f57c9469a84a159d8abecf793a5bcff
+  React-RCTBlob: e00f9b4e2f151938f4d9864cf33ebf24ac03328a
+  React-RCTFabric: 3945d116fd271598db262d4e6ed5691d431ed9e8
+  React-RCTFBReactNativeSpec: 0f4d4f0da938101f2ca9d5333a8f46e527ad2819
+  React-RCTImage: dac5e9f8ec476aefe6e60ee640ebc1dfaf1a4dbe
+  React-RCTLinking: 494b785a40d952a1dfbe712f43214376e5f0e408
+  React-RCTNetwork: b3d7c30cd21793e268db107dd0980cb61b3c1c44
+  React-RCTRuntime: a8ff419d437228e7b8a793b14f9d711e1cbb82af
+  React-RCTSettings: a060c7e381a3896104761b8eed7e284d95e37df3
+  React-RCTText: 4f272b72dbb61f390d8c8274528f9fdbff983806
+  React-RCTVibration: 0e5326220719aca12473d703aa46693e3b4ce67a
   React-rendererconsistency: 351fdbc5c1fe4da24243d939094a80f0e149c7a1
-  React-renderercss: 3438814bee838ae7840a633ab085ac81699fd5cf
-  React-rendererdebug: 0ac2b9419ad6f88444f066d4b476180af311fb1e
+  React-renderercss: d333f2ada83969591100d91ec6b23ca2e17e1507
+  React-rendererdebug: 039e5949b72ba63c703de020701e3fd152434c61
   React-rncore: 57ed480649bb678d8bdc386d20fee8bf2b0c307c
-  React-RuntimeApple: 8b7a9788f31548298ba1990620fe06b40de65ad7
-  React-RuntimeCore: e03d96fbd57ce69fd9bca8c925942194a5126dbc
+  React-RuntimeApple: 344a5e1105256000afabaa8df12c3e4cab880340
+  React-RuntimeCore: 0e48fb5e5160acc0334c7a723a42d42cef4b58b6
   React-runtimeexecutor: d60846710facedd1edb70c08b738119b3ee2c6c2
-  React-RuntimeHermes: aab794755d9f6efd249b61f3af4417296904e3ba
-  React-runtimescheduler: c3cd124fa5db7c37f601ee49ca0d97019acd8788
+  React-RuntimeHermes: 064286a03871d932c99738e0f8ef854962ab4b99
+  React-runtimescheduler: e917ab17ae08c204af1ebf8f669b7e411b0220c8
   React-timing: a90f4654cbda9c628614f9bee68967f1768bd6a5
-  React-utils: a612d50555b6f0f90c74b7d79954019ad47f5de6
-  ReactAppDependencyProvider: 04d5eb15eb46be6720e17a4a7fa92940a776e584
-  ReactCodegen: c63eda03ba1d94353fb97b031fc84f75a0d125ba
-  ReactCommon: 76d2dc87136d0a667678668b86f0fca0c16fdeb0
-  RNShare: a9f1a356b3f46e5395d9885687c296b116699176
+  React-utils: 51c4e71608b8133fecc9a15801d244ae7bdf3758
+  ReactAppDependencyProvider: d5dcc564f129632276bd3184e60f053fcd574d6b
+  ReactCodegen: fda99a79c866370190e162083a35602fdc314e5d
+  ReactCommon: 4d0da92a5eb8da86c08e3ec34bd23ab439fb2461
+  RNShare: a21b3cdcf22b8aa699cd54aaec8ae1c1ca709559
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: c758bfb934100bb4bf9cbaccb52557cee35e8bdf
 
 PODFILE CHECKSUM: 74b5ec2885cdfc97dce635b4ac32258ec9fa3179
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/example/package.json
+++ b/example/package.json
@@ -63,7 +63,7 @@
     "node": ">=18"
   },
   "op-sqlite": {
-    "libsql": false,
+    "libsql": true,
     "sqlcipher": false,
     "iosSqlite": false,
     "fts5": true,

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,4 +1,4 @@
-import {getDylibPath, open} from '@op-engineering/op-sqlite';
+import {getDylibPath, isLibsql, open} from '@op-engineering/op-sqlite';
 import clsx from 'clsx';
 import {useEffect, useState} from 'react';
 import {
@@ -208,6 +208,11 @@ export default function App() {
             ms
           </Text>
         )}
+        <View className="p-2">
+          <Text className="text-white">
+            is libsql: {isLibsql() ? 'YES' : 'NO'}
+          </Text>
+        </View>
         <Text
           className={clsx('font-bold flex-1 text-white p-2 mt-4', {
             'bg-green-500': allTestsPassed,

--- a/example/src/tests/queries.spec.ts
+++ b/example/src/tests/queries.spec.ts
@@ -38,37 +38,33 @@ export function queriesTests() {
         db = null;
       }
     });
-    // if (isLibsql()) {
-    //   itOnly('Remote open a turso database', async () => {
-    //     const remoteDb = openRemote({
-    //       url: 'libsql://foo-ospfranco.turso.io',
-    //       authToken:
-    //         'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJhIjoicnciLCJpYXQiOjE3MTY5NTc5OTUsImlkIjoiZmJkNzZmMjYtZTliYy00MGJiLTlmYmYtMDczZjFmMjdjOGY4In0.U3cAWBOvcdiqoPN3MB81sco7x8CGOjjtZ1ZEf30uo2iPcAmOuJzcnAznmDlZ6SpQd4qzuJxE4mAIoRlOkpzgBQ',
-    //     });
 
-    //     console.log('Running select 1');
-    //     const res = await remoteDb.execute('SELECT 1');
-    //     console.log('after select 1;');
-
-    //     expect(res.rowsAffected).to.equal(0);
-    //   });
-
-    //   // it('Open a libsql database replicated to turso', async () => {
-    //   //   const remoteDb = openSync({
-    //   //     url: 'libsql://foo-ospfranco.turso.io',
-    //   //     authToken:
-    //   //       'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJhIjoicnciLCJpYXQiOjE3MTY5NTc5OTUsImlkIjoiZmJkNzZmMjYtZTliYy00MGJiLTlmYmYtMDczZjFmMjdjOGY4In0.U3cAWBOvcdiqoPN3MB81sco7x8CGOjjtZ1ZEf30uo2iPcAmOuJzcnAznmDlZ6SpQd4qzuJxE4mAIoRlOkpzgBQ',
-    //   //     name: 'my replica',
-    //   //     syncInterval: 1000,
-    //   //   });
-
-    //   //   const res = await remoteDb.execute('SELECT 1');
-
-    //   //   remoteDb.sync();
-
-    //   //   expect(res.rowsAffected).to.equal(0);
-    //   // });
-    // }
+    if (isLibsql()) {
+      // itOnly('Remote open a turso database', async () => {
+      //   const remoteDb = openRemote({
+      //     url: 'libsql://foo-ospfranco.turso.io',
+      //     authToken:
+      //       'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJhIjoicnciLCJpYXQiOjE3MTY5NTc5OTUsImlkIjoiZmJkNzZmMjYtZTliYy00MGJiLTlmYmYtMDczZjFmMjdjOGY4In0.U3cAWBOvcdiqoPN3MB81sco7x8CGOjjtZ1ZEf30uo2iPcAmOuJzcnAznmDlZ6SpQd4qzuJxE4mAIoRlOkpzgBQ',
+      //   });
+      //   console.log('Running select 1');
+      //   const res = await remoteDb.execute('SELECT 1');
+      //   console.log('after select 1;');
+      //   expect(res.rowsAffected).to.equal(0);
+      // });
+      // it('Open a libsql database replicated to turso', async () => {
+      //   const remoteDb = openSync({
+      //     url: 'libsql://foo-ospfranco.turso.io',
+      //     authToken:
+      //       'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJhIjoicnciLCJpYXQiOjE3MTY5NTc5OTUsImlkIjoiZmJkNzZmMjYtZTliYy00MGJiLTlmYmYtMDczZjFmMjdjOGY4In0.U3cAWBOvcdiqoPN3MB81sco7x8CGOjjtZ1ZEf30uo2iPcAmOuJzcnAznmDlZ6SpQd4qzuJxE4mAIoRlOkpzgBQ',
+      //     name: 'my replica',
+      //     libsqlSyncInterval: 1000,
+      //     encryptionKey: 'blah',
+      //   });
+      //   const res = await remoteDb.execute('SELECT 1');
+      //   remoteDb.sync();
+      //   expect(res.rowsAffected).to.equal(0);
+      // });
+    }
 
     it('Can create multiple connections to same db', async () => {
       const db2 = open({

--- a/src/index.ts
+++ b/src/index.ts
@@ -633,6 +633,7 @@ export const openSync = (params: {
   location?: string;
   libsqlSyncInterval?: number;
   libsqlOffline?: boolean;
+  encryptionKey?: string;
 }): DB => {
   if (!isLibsql()) {
     throw new Error('This function is only available for libsql');


### PR DESCRIPTION
In theory this enables encryption on libsql. I tried opening the local file with tableplus (providing the same passphrase) but all I get is an error, so I've personally not been able to verify encryption is working. Running a query all I get is `Query 1 ERROR at Line 1: : SQL logic error`.

At least [this comment](https://github.com/OP-Engineering/op-sqlite/pull/286#issuecomment-2968524655) by the Turso team says that's all that is needed.

Docs have been updated as well. The `openSync` call now supports an `encryptionKey` param that will pass this to the libsql config when opening the sync connection.

Closes #224 