### PR TITLE
Fixes the issue I initially faced on android with prefab publishing

### DIFF
--- a/c_sources/tokenizers.h
+++ b/c_sources/tokenizers.h
@@ -3,7 +3,7 @@
 
 #define TOKENIZER_LIST opsqlite_wordtokenizer_init(db,&errMsg,nullptr);opsqlite_porter_init(db,&errMsg,nullptr);
 
-#include <sqlite3.h>
+#include "sqlite3.h"
 
 namespace opsqlite {
 

--- a/cpp/DBHostObject.h
+++ b/cpp/DBHostObject.h
@@ -8,7 +8,11 @@
 #ifdef OP_SQLITE_USE_LIBSQL
 #include "libsql/bridge.h"
 #else
+#ifdef __ANDROID__
+#include "sqlite3.h"
+#else
 #include <sqlite3.h>
+#endif
 #endif
 #include <unordered_map>
 #include <vector>

--- a/cpp/PreparedStatementHostObject.h
+++ b/cpp/PreparedStatementHostObject.h
@@ -7,7 +7,11 @@
 #include "libsql.h"
 #include "libsql/bridge.h"
 #else
+#ifdef __ANDROID__
+#include "sqlite3.h"
+#else
 #include <sqlite3.h>
+#endif
 #endif
 #include "OPThreadPool.h"
 #include <string>

--- a/cpp/bridge.h
+++ b/cpp/bridge.h
@@ -4,7 +4,11 @@
 #include "SmartHostObject.h"
 #include "types.h"
 #include "utils.h"
+#ifdef __ANDROID__
+#include "sqlite3.h"
+#else
 #include <sqlite3.h>
+#endif
 #include <vector>
 
 namespace opsqlite {

--- a/cpp/utils.h
+++ b/cpp/utils.h
@@ -4,7 +4,11 @@
 #include "SmartHostObject.h"
 #include "types.h"
 #include <jsi/jsi.h>
+#ifdef __ANDROID__
+#include "sqlite3.h"
+#else
 #include <sqlite3.h>
+#endif
 #include <string>
 #include <vector>
 

--- a/example/c_sources/tokenizers.h
+++ b/example/c_sources/tokenizers.h
@@ -3,7 +3,11 @@
 
 #define TOKENIZER_LIST opsqlite_wordtokenizer_init(db,&errMsg,nullptr);opsqlite_porter_init(db,&errMsg,nullptr);
 
+#ifdef __ANDROID__
+#include "sqlite3.h"
+#else
 #include <sqlite3.h>
+#endif
 
 namespace opsqlite {
 


### PR DESCRIPTION
Thought it was wroking, but sadly came across the build issues on android again where it expects "" instead of <> , guess I didn't correctly clear the cache before testing the changes: 

```
 error: 'sqlite3.h' file not found with <angled> include; use "quotes" instead
      7 | #include <sqlite3.h>
        |          ^
  2 errors generated.
  ```
  
As you stated earlier its needed to keep diamond brackets for iOS, so to fix it we can just use the macro which checks if android :

```
#ifdef __ANDROID__
#include "sqlite3.h"
#else
#include <sqlite3.h>
#endif
```

