### PR TITLE
feat: Updated lib to use openssl with 16 kb support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -276,7 +276,7 @@ dependencies {
   implementation 'com.facebook.react:react-native'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   if (useSQLCipher) {
-    implementation('io.github.ronickg:openssl:3.3.2')
+    implementation('io.github.ronickg:openssl:3.3.2-1')
   }
 }
 


### PR DESCRIPTION
Using this command one can check if it correctly supports 16kb size, found here (https://developer.android.com/guide/practices/page-sizes):

```
 ./llvm-objdump -p  libcrypto.so | grep LOAD
    LOAD off    0x0000000000000000 vaddr 0x0000000000000000 paddr 0x0000000000000000 align 2**14
    LOAD off    0x0000000000230000 vaddr 0x0000000000234000 paddr 0x0000000000234000 align 2**14
    LOAD off    0x0000000000463c70 vaddr 0x000000000046bc70 paddr 0x000000000046bc70 align 2**14
    LOAD off    0x00000000004bd190 vaddr 0x00000000004c9190 paddr 0x00000000004c9190 align 2**14
    ```