### PR TITLE
Prevent firing reactive query if value has been cleared by JS

### DIFF
--- a/cpp/DBHostObject.cpp
+++ b/cpp/DBHostObject.cpp
@@ -83,6 +83,14 @@ void DBHostObject::on_update(const std::string &table,
 
     for (const auto &query_ptr : reactive_queries) {
         auto query = query_ptr.get();
+
+        // The JS environment might have cleared the query while the update was queued
+        // For now this seems to prevent a EXC_BAD_ACCESS
+        if (query == nullptr) {
+            continue;
+        }
+
+        
         if (query->discriminators.empty()) {
             continue;
         }


### PR DESCRIPTION
Ref https://github.com/OP-Engineering/op-sqlite/issues/331 and https://github.com/OP-Engineering/op-sqlite/issues/327.

It seems if JS has cleared the values of the reactive query, C++ can still try to access the value before it has been removed from the saved queries vector