### PR TITLE
fix: prevent use-after-free during database invalidation

### DIFF
--- a/cpp/DBHostObject.cpp
+++ b/cpp/DBHostObject.cpp
@@ -671,7 +671,7 @@ void DBHostObject::invalidate() {
   }
 
   invalidated = true;
-  thread_pool->restartPool();
+  thread_pool->shutdown();
 #ifdef OP_SQLITE_USE_LIBSQL
   opsqlite_libsql_close(db);
 #else

--- a/cpp/OPThreadPool.cpp
+++ b/cpp/OPThreadPool.cpp
@@ -117,4 +117,22 @@ void ThreadPool::restartPool() {
 
   done = false;
 }
+void ThreadPool::shutdown() {
+  if (done) {
+    return;
+  }
+
+  done = true;
+
+  workQueueConditionVariable.notify_all();
+
+  for (auto &thread : threads) {
+    if (thread.joinable()) {
+      thread.join();
+    }
+  }
+
+  threads.clear();
+}
+
 } // namespace opsqlite

--- a/cpp/OPThreadPool.h
+++ b/cpp/OPThreadPool.h
@@ -17,6 +17,7 @@ public:
   void queueWork(const std::function<void(void)> &task);
   void waitFinished();
   void restartPool();
+  void shutdown();
 
 private:
   unsigned int busy{};


### PR DESCRIPTION
## Summary

Fixes an `EXC_BAD_ACCESS` crash caused by a race condition in `DBHostObject::invalidate()` where `restartPool()` creates new worker threads that can access `db` after `opsqlite_close(db)` has freed it.

## Crash trace

```
sqlite3FreeCodecArg (sqlite3.c:111639)
sqlite3PagerClose (sqlite3.c:62507)
sqlite3BtreeClose (sqlite3.c:74836)
sqlite3Close (sqlite3.c:189787)
opsqlite::DBHostObject::invalidate (DBHostObject.cpp:679)
opsqlite::DBHostObject::~DBHostObject (DBHostObject.cpp:685)
```

## Root cause

`invalidate()` calls `thread_pool->restartPool()` which:
1. Sets `done = true` and joins existing threads (correct — waits for in-flight work)
2. **Creates NEW threads** and sets `done = false` (incorrect for invalidation)

After `restartPool()` returns, the new threads are running. If any pending tasks remain in the queue, they can be dequeued and executed by these new threads — accessing `db` concurrently with or after `opsqlite_close(db)`. This causes a use-after-free in SQLCipher's codec teardown.

## Fix

Add a `ThreadPool::shutdown()` method that drains the pool and stops threads **without restarting**. Use it in `invalidate()` instead of `restartPool()`.

`shutdown()` is essentially the first half of `restartPool()` — it sets `done = true`, wakes all threads, and joins them. It does not create new threads afterward, because the database is about to be closed and no further work should be processed.

## Additional note

There is also a secondary issue where `promisify()` in `utils.cpp` checks the global `opsqlite::invalidated` flag (line 343) rather than the per-instance `DBHostObject::invalidated` flag. This means if multiple databases are open, closing one does not prevent queued tasks for that specific instance from executing. This PR does not address that issue but it would be worth considering as a follow-up.

## Test plan

- [x] Verified the fix compiles on iOS and Android
- [x] Confirmed `invalidate()` properly drains in-flight tasks before closing the database
- [x] No behavioral change for normal database operations — `shutdown()` is only called during invalidation/destruction