### PR TITLE
Resolve unused variable in plain build

### DIFF
--- a/cpp/bridge.cpp
+++ b/cpp/bridge.cpp
@@ -89,7 +89,9 @@ sqlite3 *opsqlite_open(std::string const &name, std::string const &path,
                        [[maybe_unused]] std::string const &sqlite_vec_path) {
 #endif
   std::string final_path = opsqlite_get_db_path(name, path);
+#if defined(OP_SQLITE_USE_CRSQLITE) || defined(OP_SQLITE_USE_SQLITE_VEC)
   char *errMsg;
+#endif
   sqlite3 *db;
 
   int flags =


### PR DESCRIPTION
Handles compiler warning when not adding extensions:
```
C/C++: [...]/node_modules/@op-engineering/op-sqlite/cpp/bridge.cpp:92:9: warning: unused variable 'errMsg' [-Wunused-variable]
C/C++:    92 |   char *errMsg;
C/C++:       |         ^~~~~~
C/C++: 1 warning generated.
```