### PR TITLE
fix(cpp): out-of-bounds read in delete() when a location is passed

### DIFF
--- a/cpp/DBHostObject.cpp
+++ b/cpp/DBHostObject.cpp
@@ -283,12 +283,12 @@ void DBHostObject::create_jsi_functions(jsi::Runtime &rt) {
     std::string path = std::string(base_path);
 
     if (count == 1) {
-      if (!args[1].isString()) {
+      if (!args[0].isString()) {
         throw std::runtime_error(
-            "[op-sqlite][open] database location must be a string");
+            "[op-sqlite][delete] database location must be a string");
       }
 
-      std::string location = args[1].asString(rt).utf8(rt);
+      std::string location = args[0].asString(rt).utf8(rt);
 
       if (!location.empty()) {
         if (location == ":memory:") {

--- a/example/src/tests/dbsetup.ts
+++ b/example/src/tests/dbsetup.ts
@@ -146,6 +146,38 @@ describe("DB setup tests", () => {
 		db.delete();
 	});
 
+	it("Should delete db when a location argument is passed to delete()", async () => {
+		const db = open({
+			name: "deleteWithLocationArg.sqlite",
+			encryptionKey: "test",
+		});
+
+		// Regression: delete() previously read args[1] when count == 1, which
+		// read past the JSI argument list and could crash native code. An
+		// empty-string location exercises the count == 1 / args[0] path; the
+		// empty-guard in the host function preserves the base path so the file
+		// is still found and removed.
+		db.delete("");
+	});
+
+	it("Should reject a non-string location argument to delete()", async () => {
+		const db = open({
+			name: "deleteBadArg.sqlite",
+			encryptionKey: "test",
+		});
+
+		let threw = false;
+		try {
+			// @ts-expect-error — intentionally passing a non-string to exercise the guard
+			db.delete(123);
+		} catch (e) {
+			threw = true;
+		}
+		expect(threw).toEqual(true);
+
+		db.delete();
+	});
+
 	it("Should create db in custom folder", async () => {
 		const db = open({
 			name: "customFolderTest.sqlite",


### PR DESCRIPTION
## Summary

The `delete` JSI host function in cpp/DBHostObject.cpp checks `count == 1` for the optional location argument, but then reads `args[1]` instead of `args[0]`. Calling `db.delete(location)` therefore reads past the end of the JSI argument list — undefined behaviour, can crash native code.

Also fixes a stale error string in the same block that referred to `[op-sqlite][open]` instead of `[op-sqlite][delete]`.

## Changes

- `cpp/DBHostObject.cpp`: use `args[0]` for the optional location argument; correct the error message tag.
- `example/src/tests/dbsetup.ts`: add two regression tests — one that calls `db.delete(location)` with a valid string, and one that asserts a non-string argument is rejected by the type guard.