### PR TITLE
fix(cpp): switch BLOB buffers to array shared_ptr

### DIFF
--- a/cpp/bridge.cpp
+++ b/cpp/bridge.cpp
@@ -257,7 +257,7 @@ BridgeResult opsqlite_execute_prepared_statement(
           // always copy the data
           memcpy(data, blob, blob_size);
           row.values.emplace_back(
-              ArrayBuffer{.data = std::shared_ptr<uint8_t>{data},
+              ArrayBuffer{.data = std::shared_ptr<uint8_t[]>{data},
                           .size = static_cast<size_t>(blob_size)});
           break;
         }
@@ -430,7 +430,7 @@ BridgeResult opsqlite_execute(sqlite3 *db, std::string const &query,
             auto *data = new uint8_t[blob_size];
             memcpy(data, blob, blob_size);
             row.emplace_back(
-                ArrayBuffer{.data = std::shared_ptr<uint8_t>{data},
+                ArrayBuffer{.data = std::shared_ptr<uint8_t[]>{data},
                             .size = static_cast<size_t>(blob_size)});
             break;
           }
@@ -570,7 +570,7 @@ BridgeResult opsqlite_execute_host_objects(
             // always copy the data
             memcpy(data, blob, blob_size);
             row.values.emplace_back(
-                ArrayBuffer{.data = std::shared_ptr<uint8_t>{data},
+                ArrayBuffer{.data = std::shared_ptr<uint8_t[]>{data},
                             .size = static_cast<size_t>(blob_size)});
             break;
           }
@@ -719,7 +719,7 @@ opsqlite_execute_raw(sqlite3 *db, std::string const &query,
             auto *data = new uint8_t[blob_size];
             memcpy(data, blob, blob_size);
             row.emplace_back(
-                ArrayBuffer{.data = std::shared_ptr<uint8_t>{data},
+                ArrayBuffer{.data = std::shared_ptr<uint8_t[]>{data},
                             .size = static_cast<size_t>(blob_size)});
             break;
           }

--- a/cpp/libsql/bridge.cpp
+++ b/cpp/libsql/bridge.cpp
@@ -312,7 +312,7 @@ BridgeResult opsqlite_libsql_execute_prepared_statement(
                 memcpy(data, value_blob.ptr, value_blob.len);
                 libsql_free_blob(value_blob);
                 row_host_object.values.emplace_back(
-                    ArrayBuffer{.data = std::shared_ptr<uint8_t>{data},
+                    ArrayBuffer{.data = std::shared_ptr<uint8_t[]>{data},
                                 .size = static_cast<size_t>(value_blob.len)});
                 break;
             }
@@ -466,7 +466,7 @@ BridgeResult opsqlite_libsql_execute(DB const &db, std::string const &query,
                 memcpy(data, blob_value.ptr, blob_value.len);
                 libsql_free_blob(blob_value);
                 out_row.emplace_back(
-                    ArrayBuffer{.data = std::shared_ptr<uint8_t>{data},
+                    ArrayBuffer{.data = std::shared_ptr<uint8_t[]>{data},
                                 .size = static_cast<size_t>(blob_value.len)});
                 break;
             }
@@ -571,7 +571,7 @@ BridgeResult opsqlite_libsql_execute_with_host_objects(
                 memcpy(data, value_blob.ptr, value_blob.len);
                 libsql_free_blob(value_blob);
                 row_host_object.values.emplace_back(
-                    ArrayBuffer{.data = std::shared_ptr<uint8_t>{data},
+                    ArrayBuffer{.data = std::shared_ptr<uint8_t[]>{data},
                                 .size = static_cast<size_t>(value_blob.len)});
                 break;
             }
@@ -698,7 +698,7 @@ opsqlite_libsql_execute_raw(DB const &db, std::string const &query,
                 memcpy(data, value_blob.ptr, value_blob.len);
                 libsql_free_blob(value_blob);
                 row_vector.emplace_back(
-                    ArrayBuffer{.data = std::shared_ptr<uint8_t>{data},
+                    ArrayBuffer{.data = std::shared_ptr<uint8_t[]>{data},
                                 .size = static_cast<size_t>(value_blob.len)});
                 break;
             }

--- a/cpp/turso_bridge.cpp
+++ b/cpp/turso_bridge.cpp
@@ -670,7 +670,7 @@ BridgeResult opsqlite_execute_prepared_statement(
         auto ptr = turso_statement_row_value_bytes_ptr(stmt->statement, i);
         auto *data = new uint8_t[static_cast<size_t>(size)];
         memcpy(data, ptr, static_cast<size_t>(size));
-        row.values.emplace_back(ArrayBuffer{.data = std::shared_ptr<uint8_t>{data},
+        row.values.emplace_back(ArrayBuffer{.data = std::shared_ptr<uint8_t[]>{data},
                                             .size = static_cast<size_t>(size)});
         break;
       }
@@ -787,7 +787,7 @@ BridgeResult opsqlite_execute(sqlite3 *db, std::string const &query,
           auto ptr = turso_statement_row_value_bytes_ptr(statement, i);
           auto *data = new uint8_t[static_cast<size_t>(size)];
           memcpy(data, ptr, static_cast<size_t>(size));
-          row.emplace_back(ArrayBuffer{.data = std::shared_ptr<uint8_t>{data},
+          row.emplace_back(ArrayBuffer{.data = std::shared_ptr<uint8_t[]>{data},
                                        .size = static_cast<size_t>(size)});
           break;
         }

--- a/cpp/types.hpp
+++ b/cpp/types.hpp
@@ -13,7 +13,7 @@ extern std::shared_ptr<facebook::react::CallInvoker> invoker;
 extern bool invalidated;
 
 struct ArrayBuffer {
-  std::shared_ptr<uint8_t> data;
+  std::shared_ptr<uint8_t[]> data;
   size_t size;
 };
 

--- a/cpp/utils.cpp
+++ b/cpp/utils.cpp
@@ -134,7 +134,7 @@ inline JSVariant to_variant(jsi::Runtime &rt, const jsi::Value &value) {
     uint8_t *data = new uint8_t[byteLength];
     memcpy(data, sourceData, byteLength);
 
-    return JSVariant(ArrayBuffer{.data = std::shared_ptr<uint8_t>{data},
+    return JSVariant(ArrayBuffer{.data = std::shared_ptr<uint8_t[]>{data},
                                  .size = byteLength});
   }
 


### PR DESCRIPTION
## Summary

BLOB pointers returned from `sqlite3_column_blob()` are SQLite-owned (the result memory is freed by SQLite when execution advances), so op-sqlite copies each BLOB into its own buffer with `new uint8_t[N]` before handing it off to JSI. The owning smart pointer was `std::shared_ptr<uint8_t>` — whose default deleter calls scalar `delete`, not `delete[]`. Mixing `new T[]` with scalar `delete` is undefined behaviour and can surface as heap-metadata corruption: on libc++ (iOS) and scudo (Android) the array cookie placed in front of the allocation by `new T[]` is bypassed, the allocator frees the wrong block, and follow-on allocations may crash later in unrelated code.

The fix switches the smart-pointer type to the C++17 array specialization `std::shared_ptr<uint8_t[]>`, which captures `std::default_delete<uint8_t[]>` and thus calls `delete[]` on destruction. The change is a single-character template-parameter edit at the type declaration plus every construction site.

## Changes

- `cpp/types.hpp`: `ArrayBuffer::data` field type changed from `std::shared_ptr<uint8_t>` to `std::shared_ptr<uint8_t[]>`.
- `cpp/utils.cpp`, `cpp/bridge.cpp`, `cpp/libsql/bridge.cpp`, `cpp/turso_bridge.cpp`: every `ArrayBuffer{.data = std::shared_ptr<uint8_t>{data}, ...}` construction site updated to `std::shared_ptr<uint8_t[]>{data}` (11 sites in total across SQLite, libsql and Turso execute paths — including the `executeRaw`, prepared-statement, and host-object variants).

No consumer changes were needed: every reader calls `.data.get()`, which returns `T*` identically for the scalar and array specializations.