### PR TITLE
Add ability to close db in key-value Storage class

### DIFF
--- a/example/src/tests/storage.ts
+++ b/example/src/tests/storage.ts
@@ -65,4 +65,16 @@ describe("Storage", () => {
 		const keys = storage.getAllKeys();
 		expect(keys).toDeepEqual(["quack", "quack2"]);
 	});
+
+	it("can close database sync", () => {
+		storage.setItemSync("quack", "bark");
+		const res = storage.closeSync();
+		expect(res).toEqual(undefined);
+	});
+
+	it("can close database", async () => {
+		await storage.setItem("quack", "bark");
+		const res = await storage.close();
+		expect(res).toEqual(undefined);
+	});
 });

--- a/src/Storage.ts
+++ b/src/Storage.ts
@@ -93,4 +93,12 @@ export class Storage {
 	delete() {
 		this.db.delete();
 	}
+
+	async close() {
+		await this.db.closeAsync();
+	}
+
+	closeSync() {
+		this.db.close();
+	}
 }


### PR DESCRIPTION
Related to issue #411 

### What changes
- Add 2 new functions for closing database in key-value `Storage` class: `async close()` and `closeSync()`.
- Add 2 test cases simply calling these 2 functions respectively.
