### PR TITLE
Allow customizing Storage database name

### DIFF
--- a/docs/docs/key_value_storage.md
+++ b/docs/docs/key_value_storage.md
@@ -12,6 +12,7 @@ import { Storage } from '@op-engineering/op-sqlite';
 // Storage is backed by it's own database
 // You can set the location like any other op-sqlite database
 const storage = new Storage({
+  name: 'myStorage.sqlite', // Optional, defaults to '__opsqlite_storage.sqlite'
   location: 'storage', // Optional, see location param on normal databases
   encryptionKey: 'myEncryptionKey', // Optional, only used when used against SQLCipher
 });

--- a/src/Storage.ts
+++ b/src/Storage.ts
@@ -2,6 +2,7 @@ import { isTurso, open } from './functions';
 import type { DB } from './types';
 
 type StorageOptions = {
+  name?: string;
   location?: string;
   encryptionKey?: string;
 };
@@ -13,8 +14,11 @@ type StorageOptions = {
 export class Storage {
   private db: DB;
 
-  constructor(options: StorageOptions) {
-    this.db = open({ ...options, name: '__opsqlite_storage.sqlite' });
+  constructor({
+    name = '__opsqlite_storage.sqlite',
+    ...options
+  }: StorageOptions) {
+    this.db = open({ ...options, name });
     if (!isTurso()) {
       this.db.executeSync('PRAGMA mmap_size=268435456');
     }

--- a/src/Storage.web.ts
+++ b/src/Storage.web.ts
@@ -2,6 +2,7 @@ import { openAsync } from './functions.web';
 import { type DB } from './types';
 
 type StorageOptions = {
+  name?: string;
   location?: string;
   encryptionKey?: string;
 };
@@ -9,9 +10,12 @@ type StorageOptions = {
 export class Storage {
   private dbPromise: Promise<DB>;
 
-  constructor(options: StorageOptions) {
+  constructor({
+    name = '__opsqlite_storage.sqlite',
+    ...options
+  }: StorageOptions) {
     this.dbPromise = (async () => {
-      const db = await openAsync({ ...options, name: '__opsqlite_storage.sqlite' });
+      const db = await openAsync({ ...options, name });
       await db.execute(
         'CREATE TABLE IF NOT EXISTS storage (key TEXT PRIMARY KEY, value TEXT)'
       );


### PR DESCRIPTION
This allows overriding the filename used by the Key-Value Storage (from the default `__opsqlite_storage.sqlite`).

I'm not sure if there was any particular reason for not being able to override this? 