### PR TITLE
Fix sqlcipher iOS build: exclude libsql_experimental and turso_sdk_kit xcframeworks

### DIFF
--- a/op-sqlite.podspec
+++ b/op-sqlite.podspec
@@ -150,7 +150,7 @@ Pod::Spec.new do |s|
 
   if use_sqlcipher then
     log_message.call("[OP-SQLITE] using SQLCipher")
-    exclude_files += ["cpp/sqlite3.c", "cpp/sqlite3.h", "cpp/libsql/bridge.cpp", "cpp/libsql/bridge.hpp", "ios/libsql.xcframework/**/*"]
+    exclude_files += ["cpp/sqlite3.c", "cpp/sqlite3.h", "cpp/libsql/bridge.cpp", "cpp/libsql/bridge.hpp", "ios/libsql.xcframework/**/*", "ios/libsql_experimental.xcframework/**/*", "ios/turso_sdk_kit.xcframework/**/*"]
     xcconfig[:GCC_PREPROCESSOR_DEFINITIONS] += " OP_SQLITE_USE_SQLCIPHER=1 HAVE_FULLFSYNC=1 SQLITE_HAS_CODEC SQLITE_TEMP_STORE=3 SQLITE_EXTRA_INIT=sqlcipher_extra_init SQLITE_EXTRA_SHUTDOWN=sqlcipher_extra_shutdown"
     s.dependency "OpenSSL-Universal"
   elsif use_turso then


### PR DESCRIPTION
## Problem

With `"sqlcipher": true` and CocoaPods dynamic frameworks (`use_frameworks! :linkage => :dynamic`, e.g. an Expo prebuild with `ios.useFrameworks: "dynamic"`), the iOS build fails:

```
error: Multiple commands produce '.../op_sqlite.framework/Headers/libsql.h'
```

## Root cause

The sqlcipher branch of `op-sqlite.podspec` still excludes only the obsolete `ios/libsql.xcframework` path:

```ruby
exclude_files += [..., "ios/libsql.xcframework/**/*"]
```

but the package now ships `ios/libsql_experimental.xcframework` and `ios/turso_sdk_kit.xcframework` instead. Their headers land in `source_files` and collide. The other engine branches (libsql/turso) were updated to the new names — the sqlcipher branch was missed.

Affects at least 15.2.14 through 17.1.4 (the sqlcipher exclude list is identical on `main` today).

## Fix

Add the two shipped xcframework globs to the sqlcipher `exclude_files` (kept the old `ios/libsql.xcframework` glob — it is harmless). SQLCipher builds use neither libsql nor the turso SDK, matching how the sibling branches exclude the engines they don't compile.

Verified by building an RN 0.86 app with sqlcipher + dynamic frameworks: the collision is gone and the app runs (we currently carry exactly this change as a pnpm patch on 15.2.14).