### PR TITLE
Patches around async work

### DIFF
--- a/cpp/OPThreadPool.cpp
+++ b/cpp/OPThreadPool.cpp
@@ -77,6 +77,10 @@ void ThreadPool::doWork() {
       ++busy;
     }
     task();
+    // Release the task (and everything it captured, e.g. JSI values) before
+    // signalling idle, so waitFinished()/close() can't observe busy == 0
+    // while task-owned resources are still pending destruction.
+    task = nullptr;
     {
       std::lock_guard<std::mutex> g(workQueueMutex);
       --busy;

--- a/cpp/utils.cpp
+++ b/cpp/utils.cpp
@@ -170,8 +170,8 @@ std::vector<JSVariant> to_variant_vec(jsi::Runtime &rt, jsi::Value const &xs) {
   res.reserve(arg_length);
 
   for (size_t ii = 0; ii < arg_length; ii++) {
-     res.emplace_back(to_variant(rt, values.getValueAtIndex(rt, ii)));
-   }
+    res.emplace_back(to_variant(rt, values.getValueAtIndex(rt, ii)));
+  }
 
   return res;
 }
@@ -392,6 +392,8 @@ promisify(jsi::Runtime &rt, std::shared_ptr<ThreadPool> thread_pool,
           return;
         }
 
+        // reject is also captured in the invokeAsync lambda
+        // so it can be safely disposed on the JS thread
         opsqlite::invoker->invokeAsync(
             [result = std::move(result), resolve = resolve, reject = reject,
              resolve_callback = resolve_callback](jsi::Runtime &rt) {
@@ -403,23 +405,30 @@ promisify(jsi::Runtime &rt, std::shared_ptr<ThreadPool> thread_pool,
         // runtime_error to the generic exception We have to
         // explicitly catch it
         // https://github.com/facebook/react-native/issues/48027
+        //
+        // resolve is also captured in the invokeAsync lambda
+        // so it can be safely disposed on the JS thread
         auto what = e.what();
-        opsqlite::invoker->invokeAsync(
-            [what = std::string(what), reject = reject](jsi::Runtime &rt) {
-              auto errorCtr = rt.global().getPropertyAsFunction(rt, "Error");
-              auto error = errorCtr.callAsConstructor(
-                  rt, jsi::String::createFromAscii(rt, what));
-              reject->asObject(rt).asFunction(rt).call(rt, error);
-            });
+        opsqlite::invoker->invokeAsync([what = std::string(what),
+                                        resolve = resolve,
+                                        reject = reject](jsi::Runtime &rt) {
+          auto errorCtr = rt.global().getPropertyAsFunction(rt, "Error");
+          auto error = errorCtr.callAsConstructor(
+              rt, jsi::String::createFromAscii(rt, what));
+          reject->asObject(rt).asFunction(rt).call(rt, error);
+        });
       } catch (std::exception &exc) {
         auto what = exc.what();
-        opsqlite::invoker->invokeAsync(
-            [what = std::string(what), reject = reject](jsi::Runtime &rt) {
-              auto errorCtr = rt.global().getPropertyAsFunction(rt, "Error");
-              auto error = errorCtr.callAsConstructor(
-                  rt, jsi::String::createFromAscii(rt, what));
-              reject->asObject(rt).asFunction(rt).call(rt, error);
-            });
+        // resolve is also captured in the invokeAsync lambda
+        // so it can be safely disposed on the JS thread
+        opsqlite::invoker->invokeAsync([what = std::string(what),
+                                        resolve = resolve,
+                                        reject = reject](jsi::Runtime &rt) {
+          auto errorCtr = rt.global().getPropertyAsFunction(rt, "Error");
+          auto error = errorCtr.callAsConstructor(
+              rt, jsi::String::createFromAscii(rt, what));
+          reject->asObject(rt).asFunction(rt).call(rt, error);
+        });
       }
     };
 

--- a/cpp/utils.cpp
+++ b/cpp/utils.cpp
@@ -383,8 +383,7 @@ promisify(jsi::Runtime &rt, std::shared_ptr<ThreadPool> thread_pool,
     auto resolve = std::make_shared<jsi::Value>(rt, args[0]);
     auto reject = std::make_shared<jsi::Value>(rt, args[1]);
 
-    auto task = [lambda = lambda, thread_pool,
-                 resolve_callback = resolve_callback,
+    auto task = [lambda = lambda, resolve_callback = resolve_callback,
                  resolve = std::move(resolve), reject = std::move(reject)]() {
       try {
         std::any result = lambda();
@@ -394,7 +393,7 @@ promisify(jsi::Runtime &rt, std::shared_ptr<ThreadPool> thread_pool,
         }
 
         opsqlite::invoker->invokeAsync(
-            [result = std::move(result), resolve = resolve,
+            [result = std::move(result), resolve = resolve, reject = reject,
              resolve_callback = resolve_callback](jsi::Runtime &rt) {
               auto jsi_result = resolve_callback(rt, result);
               resolve->asObject(rt).asFunction(rt).call(rt, jsi_result);


### PR DESCRIPTION
From discord

> we're crashing whenever the JS runtime reloads in a live process (CodePush OTA,
RN 0.81 to 0.85, op-sqlite 16.2.2): ~jsi::Value() on ThreadPool::doWork() and
thread::join failed: Resource deadlock avoided.
>
> Two things look suspect in cpp/: promisify's task captures a shared_ptr<ThreadPool>
it never uses, so the worker can end up joining itself, and the success path
re-captures only resolve, so reject gets destroyed on the pool thread every
query. doWork() also decrements busy before destroying the task, so
waitFinished() and close() can return early.

This seem to be indeed valid findings:
- The thread pool does not need to be captured, as it will try to join itself on it's destructor. Likely an remnant when I was writing this abstractions by hand
- The reject needs to be captured in the lambda so it can safely destroyed in the JS thread
- The task needs to be cleared before the busy counter goes down so it resources can be properly cleaned up