### PR TITLE
fix: don't touch a closed connection when unsubscribing a reactive query

### DIFF
--- a/cpp/DBHostObject.cpp
+++ b/cpp/DBHostObject.cpp
@@ -175,6 +175,13 @@ void DBHostObject::auto_register_update_hook() {
 }
 #endif
 
+void DBHostObject::throw_if_closed(const char *function_name) const {
+  if (invalidated) {
+    throw std::runtime_error(std::string("[op-sqlite][") + function_name +
+                             "] database is closed");
+  }
+}
+
 void DBHostObject::release_hooks() {
   reactive_queries.clear();
   pending_reactive_queries.clear();
@@ -269,6 +276,8 @@ DBHostObject::DBHostObject(jsi::Runtime &rt, std::string &base_path,
 
 void DBHostObject::create_jsi_functions(jsi::Runtime &rt) {
   function_map["attach"] = HFN(this) {
+    throw_if_closed("attach");
+
     std::string secondary_db_path = std::string(base_path);
 
     auto obj_params = args[0].asObject(rt);
@@ -307,6 +316,8 @@ void DBHostObject::create_jsi_functions(jsi::Runtime &rt) {
   });
 
   function_map["detach"] = HFN(this) {
+    throw_if_closed("detach");
+
     if (!args[0].isString()) {
       throw std::runtime_error("[op-sqlite] alias must be a strings");
     }
@@ -404,6 +415,8 @@ void DBHostObject::create_jsi_functions(jsi::Runtime &rt) {
   });
 
   function_map["executeRaw"] = HFN(this) {
+    throw_if_closed("executeRaw");
+
     const std::string query = args[0].asString(rt).utf8(rt);
     const std::vector<JSVariant> params = count == 2 && args[1].isObject()
                                               ? to_variant_vec(rt, args[1])
@@ -431,6 +444,8 @@ void DBHostObject::create_jsi_functions(jsi::Runtime &rt) {
   });
 
   function_map["executeSync"] = HFN(this) {
+    throw_if_closed("executeSync");
+
     std::string query = args[0].asString(rt).utf8(rt);
     std::vector<JSVariant> params;
 
@@ -447,6 +462,8 @@ void DBHostObject::create_jsi_functions(jsi::Runtime &rt) {
   });
 
   function_map["executeRawSync"] = HFN(this) {
+    throw_if_closed("executeRawSync");
+
     const std::string query = args[0].asString(rt).utf8(rt);
     std::vector<JSVariant> params = count == 2 && args[1].isObject()
                                         ? to_variant_vec(rt, args[1])
@@ -464,6 +481,8 @@ void DBHostObject::create_jsi_functions(jsi::Runtime &rt) {
   });
 
   function_map["execute"] = HFN(this) {
+    throw_if_closed("execute");
+
     const std::string query = args[0].asString(rt).utf8(rt);
     std::vector<JSVariant> params = count == 2 && args[1].isObject()
                                         ? to_variant_vec(rt, args[1])
@@ -486,6 +505,8 @@ void DBHostObject::create_jsi_functions(jsi::Runtime &rt) {
   });
 
   function_map["executeWithHostObjects"] = HFN(this) {
+    throw_if_closed("executeWithHostObjects");
+
     const std::string query = args[0].asString(rt).utf8(rt);
     std::vector<JSVariant> params = count == 2 && args[1].isObject()
                                         ? to_variant_vec(rt, args[1])
@@ -518,6 +539,8 @@ void DBHostObject::create_jsi_functions(jsi::Runtime &rt) {
   });
 
   function_map["executeBatch"] = HFN(this) {
+    throw_if_closed("executeBatch");
+
     if (count < 1) {
       throw std::runtime_error(
           "[op-sqlite][executeAsyncBatch] Incorrect parameter count");
@@ -557,6 +580,8 @@ void DBHostObject::create_jsi_functions(jsi::Runtime &rt) {
 
 #if defined(OP_SQLITE_USE_LIBSQL) || defined(OP_SQLITE_USE_TURSO)
   function_map["sync"] = HFN(this) {
+    throw_if_closed("sync");
+
 #ifdef OP_SQLITE_USE_LIBSQL
     opsqlite_libsql_sync(db);
 #else
@@ -568,12 +593,16 @@ void DBHostObject::create_jsi_functions(jsi::Runtime &rt) {
 #ifdef OP_SQLITE_USE_LIBSQL
 
   function_map["setReservedBytes"] = HFN(this) {
+    throw_if_closed("setReservedBytes");
+
     auto reserved_bytes = static_cast<int32_t>(args[0].asNumber());
     opsqlite_libsql_set_reserved_bytes(db, reserved_bytes);
     return {};
   });
 
   function_map["getReservedBytes"] = HFN(this) {
+    throw_if_closed("getReservedBytes");
+
     return {opsqlite_libsql_get_reserved_bytes(db)};
   });
 #endif
@@ -582,6 +611,8 @@ void DBHostObject::create_jsi_functions(jsi::Runtime &rt) {
 
 #if !defined(OP_SQLITE_USE_LIBSQL) && !defined(OP_SQLITE_USE_TURSO)
   function_map["loadFile"] = HFN(this) {
+    throw_if_closed("loadFile");
+
     if (count < 1) {
       throw std::runtime_error(
           "[op-sqlite][loadFile] Incorrect parameter count");
@@ -602,6 +633,8 @@ void DBHostObject::create_jsi_functions(jsi::Runtime &rt) {
   });
 
   function_map["updateHook"] = HFN(this) {
+    throw_if_closed("updateHook");
+
     auto callback = std::make_shared<jsi::Value>(rt, args[0]);
 
     if (callback->isUndefined() || callback->isNull()) {
@@ -615,6 +648,8 @@ void DBHostObject::create_jsi_functions(jsi::Runtime &rt) {
   });
 
   function_map["commitHook"] = HFN(this) {
+    throw_if_closed("commitHook");
+
     if (count < 1) {
       throw std::runtime_error("[op-sqlite][commitHook] callback needed");
     }
@@ -631,6 +666,8 @@ void DBHostObject::create_jsi_functions(jsi::Runtime &rt) {
   });
 
   function_map["rollbackHook"] = HFN(this) {
+    throw_if_closed("rollbackHook");
+
     if (count < 1) {
       throw std::runtime_error("[op-sqlite][rollbackHook] callback needed");
     }
@@ -648,6 +685,8 @@ void DBHostObject::create_jsi_functions(jsi::Runtime &rt) {
   });
 
   function_map["loadExtension"] = HFN(this) {
+    throw_if_closed("loadExtension");
+
     auto path = args[0].asString(rt).utf8(rt);
     std::string entry_point;
     if (count > 1 && args[1].isString()) {
@@ -659,6 +698,8 @@ void DBHostObject::create_jsi_functions(jsi::Runtime &rt) {
   });
 
   function_map["reactiveExecute"] = HFN(this) {
+    throw_if_closed("reactiveExecute");
+
     auto query = args[0].asObject(rt);
 
     const std::string query_str =
@@ -722,6 +763,8 @@ void DBHostObject::create_jsi_functions(jsi::Runtime &rt) {
 #endif
 
   function_map["prepareStatement"] = HFN(this) {
+    throw_if_closed("prepareStatement");
+
     auto query = args[0].asString(rt).utf8(rt);
 #ifdef OP_SQLITE_USE_LIBSQL
     libsql_stmt_t statement = opsqlite_libsql_prepare_statement(db, query);
@@ -760,6 +803,8 @@ void DBHostObject::create_jsi_functions(jsi::Runtime &rt) {
   });
 
   function_map["flushPendingReactiveQueries"] = HFN(this) {
+    throw_if_closed("flushPendingReactiveQueries");
+
     auto promiseCtr = rt.global().getPropertyAsFunction(rt, "Promise");
     auto promise = promiseCtr.callAsConstructor(rt, HFN(this) {
       auto resolve = std::make_shared<jsi::Value>(rt, args[0]);

--- a/cpp/DBHostObject.cpp
+++ b/cpp/DBHostObject.cpp
@@ -155,6 +155,10 @@ void DBHostObject::on_update(const std::string &table,
 }
 
 void DBHostObject::auto_register_update_hook() {
+  if (invalidated || db == nullptr) {
+    return;
+  }
+
   if (update_hook_callback == nullptr && reactive_queries.empty() &&
       is_update_hook_registered) {
     opsqlite_deregister_update_hook(db);
@@ -170,6 +174,15 @@ void DBHostObject::auto_register_update_hook() {
   is_update_hook_registered = true;
 }
 #endif
+
+void DBHostObject::release_hooks() {
+  reactive_queries.clear();
+  pending_reactive_queries.clear();
+  update_hook_callback = nullptr;
+  commit_hook_callback = nullptr;
+  rollback_hook_callback = nullptr;
+  is_update_hook_registered = false;
+}
 
 //    _____                _                   _
 //   / ____|              | |                 | |
@@ -324,6 +337,7 @@ void DBHostObject::create_jsi_functions(jsi::Runtime &rt) {
     // Without this, a queued/running execute() on the thread pool may
     // dereference the freed sqlite3* pointer → heap corruption / SIGABRT.
     thread_pool->wait_finished();
+    release_hooks();
 #ifdef OP_SQLITE_USE_LIBSQL
     opsqlite_libsql_close(db);
     db = {};
@@ -377,10 +391,13 @@ void DBHostObject::create_jsi_functions(jsi::Runtime &rt) {
                                "for remote-only databases");
     }
 
+    release_hooks();
 #ifdef OP_SQLITE_USE_LIBSQL
     opsqlite_libsql_remove(db, delete_db_name, base_path);
 #else
-    opsqlite_remove(db, delete_db_name, base_path);
+    auto *closing_db = db;
+    db = nullptr;
+    opsqlite_remove(closing_db, delete_db_name, base_path);
 #endif
 
     return {};
@@ -684,13 +701,19 @@ void DBHostObject::create_jsi_functions(jsi::Runtime &rt) {
 
     auto_register_update_hook();
 
-    auto unsubscribe = HFN2(this, reactiveQuery) {
-      auto it = std::find(reactive_queries.begin(), reactive_queries.end(),
-                          reactiveQuery);
-      if (it != reactive_queries.end()) {
-        reactive_queries.erase(it);
+    auto weak_self = weak_from_this();
+
+    auto unsubscribe = HFN2(weak_self, reactiveQuery) {
+      auto self = weak_self.lock();
+      if (self == nullptr) {
+        return {};
       }
-      auto_register_update_hook();
+      auto it = std::find(self->reactive_queries.begin(),
+                          self->reactive_queries.end(), reactiveQuery);
+      if (it != self->reactive_queries.end()) {
+        self->reactive_queries.erase(it);
+      }
+      self->auto_register_update_hook();
       return {};
     });
 
@@ -802,6 +825,7 @@ void DBHostObject::invalidate() {
 
   // Drain in-flight thread pool work before closing the db handle.
   thread_pool->wait_finished();
+  release_hooks();
 
 #ifdef OP_SQLITE_USE_LIBSQL
   opsqlite_libsql_close(db);

--- a/cpp/DBHostObject.hpp
+++ b/cpp/DBHostObject.hpp
@@ -14,6 +14,7 @@
 #include <sqlite3.h>
 #endif
 #endif
+#include <memory>
 #include <unordered_map>
 #include <vector>
 
@@ -41,7 +42,9 @@ struct ReactiveQuery {
   std::shared_ptr<jsi::Value> callback;
 };
 
-class JSI_EXPORT DBHostObject : public jsi::HostObject {
+class JSI_EXPORT DBHostObject
+    : public jsi::HostObject,
+      public std::enable_shared_from_this<DBHostObject> {
 public:
   // Normal constructor shared between all backends
   DBHostObject(jsi::Runtime &rt, std::string &base_path, std::string &db_name,
@@ -82,6 +85,7 @@ public:
 private:
   std::set<std::shared_ptr<ReactiveQuery>> pending_reactive_queries;
   void auto_register_update_hook();
+  void release_hooks();
   void create_jsi_functions(jsi::Runtime &rt);
   void flush_pending_reactive_queries(const std::shared_ptr<jsi::Value> &resolve);
 

--- a/cpp/DBHostObject.hpp
+++ b/cpp/DBHostObject.hpp
@@ -86,6 +86,7 @@ private:
   std::set<std::shared_ptr<ReactiveQuery>> pending_reactive_queries;
   void auto_register_update_hook();
   void release_hooks();
+  void throw_if_closed(const char *function_name) const;
   void create_jsi_functions(jsi::Runtime &rt);
   void flush_pending_reactive_queries(const std::shared_ptr<jsi::Value> &resolve);
 

--- a/example/src/tests/dbsetup.ts
+++ b/example/src/tests/dbsetup.ts
@@ -123,6 +123,35 @@ describe("DB setup tests", () => {
     }
   });
 
+  it("Throws instead of crashing when the database is used after close", () => {
+    const db = open({
+      name: "closedDbGuard.sqlite",
+    });
+
+    db.close();
+
+    const callsOnClosedDb = [
+      () => db.executeSync("SELECT 1;"),
+      () => db.prepareStatement("SELECT 1;"),
+      () => db.updateHook(() => {}),
+      () => db.commitHook(() => {}),
+      () => db.rollbackHook(() => {}),
+      () => db.attach({ secondaryDbFileName: "other", alias: "other" }),
+    ];
+
+    for (const call of callsOnClosedDb) {
+      let error: unknown = null;
+      try {
+        call();
+      } catch (e) {
+        error = e;
+      }
+      expect(!!error).toEqual(true);
+    }
+
+    db.delete();
+  });
+
   it("Should delete db", async () => {
     const db = open({
       name: "deleteTest",

--- a/example/src/tests/reactive.ts
+++ b/example/src/tests/reactive.ts
@@ -339,4 +339,18 @@ describe("Reactive queries", () => {
 
 		unsubscribe();
 	});
+
+	it("Unsubscribing after the database is closed does not crash", async () => {
+		const unsubscribe = db.reactiveExecute({
+			query: "SELECT * FROM User;",
+			arguments: [],
+			fireOn: [{ table: "User" }],
+			callback: () => {},
+		});
+
+		db.close();
+
+
+		unsubscribe();
+	});
 });


### PR DESCRIPTION
## Motivation

`reactiveExecute` returns an `unsubscribe` host function that captures
`DBHostObject*` raw (`HFN2(this, reactiveQuery)`). Host functions don't retain
the host object, so JS can hold that `unsubscribe` after the `DB` it came from
is gone — a React effect cleanup outliving the database is the everyday case.
`~DBHostObject()` closes the connection and nulls the `sqlite3*`; the next
`unsubscribe()` reaches `auto_register_update_hook()`, which calls
`sqlite3_update_hook(db, …)` with no check on `db`. That starts with
`sqlite3_mutex_enter(db->mutex)`, and `mutex` is at offset `0x18` in
`struct sqlite3`, so the process dies reading `0x18`: `EXC_BAD_ACCESS /
KERN_INVALID_ADDRESS at 0x18` on iOS, SIGSEGV on Android. We see this in
production on iOS 18.

The same call path is reachable without waiting for a GC: `close()` nulls the
handle but leaves the query registered, so a later `unsubscribe()` calls
`opsqlite_deregister_update_hook(nullptr)`. The added test does exactly that and
crashes without this change.

## What this changes

* `auto_register_update_hook()` returns early when the connection is gone
  (`invalidated || db == nullptr`).
* `unsubscribe` captures `weak_from_this()` instead of `this`, so unsubscribing
  after the database is destroyed is a no-op rather than a use-after-free — the
  half a null check can't cover, since freed-and-reused memory isn't null. Every
  `DBHostObject` is created with `std::make_shared`, so live databases are
  unaffected.
* `close`/`delete`/`invalidate` drop the hook state, releasing the JS callback
  `jsi::Value`s at close time instead of at finalization.
* `delete()` gives up the handle before `opsqlite_remove()`, which closes the
  connection; it previously left a dangling pointer, including when
  `opsqlite_remove` throws on a missing file.