### PR TITLE
Skip redundant sqlite3_clear_bindings and long long disambiguation on hot insert path

### DIFF
--- a/cpp/OPBridge.cpp
+++ b/cpp/OPBridge.cpp
@@ -25,8 +25,11 @@
 namespace opsqlite {
 
 inline void opsqlite_bind_statement(sqlite3_stmt *statement,
-                                    const std::vector<JSVariant> *values) {
-  sqlite3_clear_bindings(statement);
+                                    const std::vector<JSVariant> *values,
+                                    bool should_clear_bindings) {
+  if (should_clear_bindings) {
+    sqlite3_clear_bindings(statement);
+  }
 
   size_t size = values->size();
 
@@ -386,7 +389,7 @@ BridgeResult opsqlite_execute(sqlite3 *db, std::string const &query,
     }
 
     if (params != nullptr && !params->empty()) {
-      opsqlite_bind_statement(statement, params);
+      opsqlite_bind_statement(statement, params, /* should_clear_bindings */ false);
     }
 
     // sqlite3_column_count is the correct signal: it's non-zero for any
@@ -527,7 +530,7 @@ BridgeResult opsqlite_execute_host_objects(
     }
 
     if (params != nullptr && !params->empty()) {
-      opsqlite_bind_statement(statement, params);
+      opsqlite_bind_statement(statement, params, /* should_clear_bindings */ false);
     }
 
     int i, count, column_type;
@@ -685,7 +688,7 @@ opsqlite_execute_raw(sqlite3 *db, std::string const &query,
     }
 
     if (params != nullptr && !params->empty()) {
-      opsqlite_bind_statement(statement, params);
+      opsqlite_bind_statement(statement, params, /* should_clear_bindings */ false);
     }
 
     int i, column_type;

--- a/cpp/OPBridge.hpp
+++ b/cpp/OPBridge.hpp
@@ -90,7 +90,8 @@ sqlite3_stmt *opsqlite_prepare_statement(sqlite3 *db, std::string const &query);
 void opsqlite_finalize_statement(sqlite3_stmt *statement);
 
 void opsqlite_bind_statement(sqlite3_stmt *statement,
-                             const std::vector<JSVariant> *params);
+                             const std::vector<JSVariant> *params,
+                             bool should_clear_bindings = true);
 
 BridgeResult opsqlite_execute_prepared_statement(
     sqlite3 *db, sqlite3_stmt *statement, std::vector<DumbHostObject> *results,

--- a/cpp/OPDatabase.cpp
+++ b/cpp/OPDatabase.cpp
@@ -714,7 +714,7 @@ void OPDatabase::create_jsi_functions(jsi::Runtime &rt,
     auto variant_args = to_variant_vec(rt, js_args);
 
     sqlite3_stmt *stmt = opsqlite_prepare_statement(db, query_str);
-    opsqlite_bind_statement(stmt, &variant_args);
+    opsqlite_bind_statement(stmt, &variant_args, /* should_clear_bindings */ false);
 
     auto callback =
         std::make_shared<jsi::Value>(query.getProperty(rt, "callback"));

--- a/cpp/OPUtils.cpp
+++ b/cpp/OPUtils.cpp
@@ -83,13 +83,14 @@ JSVariant to_variant(jsi::Runtime &rt, const jsi::Value &value) {
   } else if (value.isBool()) {
     return JSVariant(value.getBool());
   } else if (value.isNumber()) {
+    // Binding only ever emits sqlite3_bind_int (below) or sqlite3_bind_double
+    // (see opsqlite_bind_statement) — the long long alternative always fell
+    // through to sqlite3_bind_double anyway, so it added a redundant cast
+    // and comparison here for no behavioral difference.
     double doubleVal = value.asNumber();
     int intVal = (int)doubleVal;
-    long long longVal = (long)doubleVal;
     if (intVal == doubleVal) {
       return JSVariant(intVal);
-    } else if (longVal == doubleVal) {
-      return JSVariant(longVal);
     } else {
       return JSVariant(doubleVal);
     }

--- a/cpp/OPUtils.cpp
+++ b/cpp/OPUtils.cpp
@@ -9,12 +9,44 @@
 #include "OPMacros.hpp"
 #include <fstream>
 #include <sys/stat.h>
+#include <unordered_map>
 #include <utility>
 
 namespace opsqlite {
 
 namespace jsi = facebook::jsi;
 namespace react = facebook::react;
+
+namespace {
+
+// "rowsAffected"/"insertId"/"rows" are set on every execute() result
+// regardless of query, so their PropNameIDs are worth caching the same way
+// column_prop_ids are reused across rows -- except these are reused across
+// *calls* too. PropNameID is a handle scoped to the jsi::Runtime that
+// created it, and runtime "generations" can briefly overlap during a
+// bridgeless reload (see OPTypes.hpp), so the cache is keyed by Runtime*
+// rather than a single global. thread_local because JSI runtime access is
+// always confined to one thread at a time; no lock needed.
+struct ResultPropNames {
+  jsi::PropNameID rowsAffected;
+  jsi::PropNameID insertId;
+  jsi::PropNameID rows;
+};
+
+ResultPropNames &result_prop_names(jsi::Runtime &rt) {
+  static thread_local std::unordered_map<jsi::Runtime *, ResultPropNames> cache;
+  auto it = cache.find(&rt);
+  if (it != cache.end()) {
+    return it->second;
+  }
+  auto [inserted, _] = cache.emplace(
+      &rt, ResultPropNames{jsi::PropNameID::forAscii(rt, "rowsAffected"),
+                           jsi::PropNameID::forAscii(rt, "insertId"),
+                           jsi::PropNameID::forAscii(rt, "rows")});
+  return inserted->second;
+}
+
+} // namespace
 
 jsi::Value to_jsi(jsi::Runtime &rt, const JSVariant &value) {
   if (std::holds_alternative<bool>(value)) {
@@ -178,18 +210,19 @@ std::vector<JSVariant> to_variant_vec(jsi::Runtime &rt, jsi::Value const &xs) {
 }
 
 jsi::Value create_js_rows(jsi::Runtime &rt, const BridgeResult &status) {
+  auto &prop_names = result_prop_names(rt);
   jsi::Object res = jsi::Object(rt);
 
-  res.setProperty(rt, "rowsAffected", status.affectedRows);
+  res.setProperty(rt, prop_names.rowsAffected, status.affectedRows);
   if (status.affectedRows > 0 && status.insertId != 0) {
-    res.setProperty(rt, "insertId", jsi::Value(status.insertId));
+    res.setProperty(rt, prop_names.insertId, jsi::Value(status.insertId));
   }
 
   size_t row_count = status.rows.size();
   size_t column_count = status.column_names.size();
 
   if (row_count == 0) {
-    res.setProperty(rt, "rows", jsi::Array(rt, 0));
+    res.setProperty(rt, prop_names.rows, jsi::Array(rt, 0));
     return res;
   }
 
@@ -208,7 +241,7 @@ jsi::Value create_js_rows(jsi::Runtime &rt, const BridgeResult &status) {
     }
     rows.setValueAtIndex(rt, i, std::move(row));
   }
-  res.setProperty(rt, "rows", std::move(rows));
+  res.setProperty(rt, prop_names.rows, std::move(rows));
 
   return res;
 }
@@ -217,11 +250,12 @@ jsi::Value
 create_result(jsi::Runtime &rt, const BridgeResult &status,
               std::vector<DumbHostObject> *results,
               std::shared_ptr<std::vector<SmartHostObject>> metadata) {
+  auto &prop_names = result_prop_names(rt);
   jsi::Object res = jsi::Object(rt);
 
-  res.setProperty(rt, "rowsAffected", status.affectedRows);
+  res.setProperty(rt, prop_names.rowsAffected, status.affectedRows);
   if (status.affectedRows > 0 && status.insertId != 0) {
-    res.setProperty(rt, "insertId", jsi::Value(status.insertId));
+    res.setProperty(rt, prop_names.insertId, jsi::Value(status.insertId));
   }
 
   size_t rowCount = results->size();
@@ -233,7 +267,7 @@ create_result(jsi::Runtime &rt, const BridgeResult &status,
                           jsi::Object::createFromHostObject(
                               rt, std::make_shared<DumbHostObject>(obj)));
   }
-  res.setProperty(rt, "rows", std::move(array));
+  res.setProperty(rt, prop_names.rows, std::move(array));
 
   size_t column_count = metadata->size();
   auto column_array = jsi::Array(rt, column_count);
@@ -252,6 +286,7 @@ create_result(jsi::Runtime &rt, const BridgeResult &status,
 jsi::Value
 create_raw_result(jsi::Runtime &rt, const BridgeResult &status,
                   const std::vector<std::vector<JSVariant>> *results) {
+  auto &prop_names = result_prop_names(rt);
   size_t row_count = results->size();
   jsi::Object res(rt);
   jsi::Array raw_rows = jsi::Array(rt, row_count);
@@ -271,8 +306,8 @@ create_raw_result(jsi::Runtime &rt, const BridgeResult &status,
         rt, i, jsi::String::createFromUtf8(rt, status.column_names.at(i)));
   }
 
-  res.setProperty(rt, "rowsAffected", status.affectedRows);
-  res.setProperty(rt, "insertId", status.insertId);
+  res.setProperty(rt, prop_names.rowsAffected, status.affectedRows);
+  res.setProperty(rt, prop_names.insertId, status.insertId);
   res.setProperty(rt, "rawRows", std::move(raw_rows));
   res.setProperty(rt, "columnNames", std::move(column_names));
 

--- a/cpp/turso/OPTursoBridge.cpp
+++ b/cpp/turso/OPTursoBridge.cpp
@@ -345,7 +345,8 @@ void reset_statement(turso_statement_t *statement) {
 } // namespace
 
 void opsqlite_bind_statement(sqlite3_stmt *statement,
-                             const std::vector<JSVariant> *values) {
+                             const std::vector<JSVariant> *values,
+                             [[maybe_unused]] bool should_clear_bindings) {
   auto *stmt = to_turso_stmt(statement);
 
   for (size_t i = 0; i < values->size(); i++) {


### PR DESCRIPTION
## Summary
- Skip the unconditional `sqlite3_clear_bindings` call in `opsqlite_bind_statement` when the statement was just freshly prepared (`execute`/`executeSync`/`reactiveExecute` paths) — bindings are already unset on a fresh `sqlite3_prepare_v2`, so this was pure overhead on every call. `PreparedStatementHostObject::bind`/`bindSync`, which reuse a persistent statement across multiple calls, keep the clear via a new `should_clear_bindings` flag (defaults to `true`, so callers I didn't touch are unaffected).
- Simplify `to_variant`'s number branch: the `long long` disambiguation always fell through to `sqlite3_bind_double` downstream anyway (same as the plain `double` branch), so it was doing an extra cast + comparison per numeric parameter for no behavioral difference.
- Cache the `PropNameID`s for `"rowsAffected"`/`"insertId"`/`"rows"` per `jsi::Runtime`, reused the same way `column_prop_ids` are already reused across rows within a call — except these are reused across *calls* too, since they're set on every `execute()` result regardless of query. `Object::setProperty(rt, const char*, ...)` allocates a fresh `jsi::String` via `String::createFromAscii` on every call, which this avoids. Keyed by `Runtime*` (not a single global) since runtime generations can briefly overlap during a bridgeless reload — see the `generation_alive` comment in `OPTypes.hpp`.

## Why
Found while benchmarking op-sqlite against `react-native-nitro-sqlite` on 1000 sequential single-row inserts — op-sqlite was unexpectedly slower on both sync and async inserts despite having fewer abstraction layers. These changes remove fixed per-call overhead on the bind and result-marshaling paths that scales with insert volume.

## Test plan
- [ ] Existing test suite passes (sync/async execute, transactions, prepared statements)
- [ ] Re-run insert benchmark to confirm the throughput gap narrows
- [ ] Sanity-check `PreparedStatementHostObject.bind()` reused across multiple `execute()` calls with varying param values still binds correctly (this is the one path that still clears bindings)
- [ ] Sanity-check a bridgeless reload (two runtime generations briefly overlapping) doesn't hit a stale/cross-runtime `PropNameID`