### PR TITLE
feat: add watchOS support

### DIFF
--- a/op-sqlite.podspec
+++ b/op-sqlite.podspec
@@ -97,7 +97,7 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => min_ios_version_supported, :tvos => "13.0", :osx => "10.15", :visionos => "1.0" }
+  s.platforms    = { :ios => min_ios_version_supported, :tvos => "13.0", :osx => "10.15", :visionos => "1.0", :watchos => "9.0" }
   s.source       = { :git => "https://github.com/op-engineering/op-sqlite.git", :tag => "#{s.version}" }
 
   log_message.call("[OP-SQLITE] Configuration found at #{package_json_path}")


### PR DESCRIPTION
I am one of the maintainers of [react-native-watchos](https://github.com/appsent-co/react-native-watchos). We've been using this small patch to let our watchOS apps pick up op-sqlite through autolinking, and I'd like to contribute it back. It adds watchOS 9.0 to the podspec's supported platforms.

Ruby syntax and `git diff --check` pass.
